### PR TITLE
Add send payment API

### DIFF
--- a/lib/db/db-client.ts
+++ b/lib/db/db-client.ts
@@ -1,9 +1,19 @@
-import { createStore, type StoreApi } from "zustand/vanilla"
+import { type HoistedStoreApi, hoist } from "zustand-hoist"
 import { immer } from "zustand/middleware/immer"
-import { hoist, type HoistedStoreApi } from "zustand-hoist"
+import { type StoreApi, createStore } from "zustand/vanilla"
 
-import { databaseSchema, type DatabaseSchema, type Thing } from "./schema.ts"
 import { combine } from "zustand/middleware"
+import {
+  type DatabaseSchema,
+  type Payment,
+  type Thing,
+  databaseSchema,
+} from "./schema.ts"
+
+type SendPaymentInput = Omit<
+  Payment,
+  "payment_id" | "status" | "transfer_reference" | "created_at"
+>
 
 export const createDatabase = () => {
   return hoist(createStore(initializer))
@@ -11,7 +21,7 @@ export const createDatabase = () => {
 
 export type DbClient = ReturnType<typeof createDatabase>
 
-const initializer = combine(databaseSchema.parse({}), (set) => ({
+const initializer = combine(databaseSchema.parse({}), (set, get) => ({
   addThing: (thing: Omit<Thing, "thing_id">) => {
     set((state) => ({
       things: [
@@ -20,5 +30,47 @@ const initializer = combine(databaseSchema.parse({}), (set) => ({
       ],
       idCounter: state.idCounter + 1,
     }))
+  },
+  sendPayment: (paymentInput: SendPaymentInput) => {
+    if (paymentInput.idempotency_key) {
+      const replayedPayment = get().payments.find(
+        (payment) => payment.idempotency_key === paymentInput.idempotency_key,
+      )
+
+      if (replayedPayment) {
+        return { payment: replayedPayment, replayed: true }
+      }
+    }
+
+    const payment: Payment = {
+      ...paymentInput,
+      payment_id: `pay_${get().idCounter}`,
+      status: "sent",
+      transfer_reference: `fake_algora_${get().idCounter}`,
+      created_at: new Date().toISOString(),
+    }
+
+    set((state) => ({
+      payments: [...state.payments, payment],
+      idCounter: state.idCounter + 1,
+    }))
+
+    return { payment, replayed: false }
+  },
+  listPayments: (filters?: {
+    recipient?: string
+    bounty_id?: string
+  }) => {
+    return get().payments.filter((payment) => {
+      if (filters?.recipient && payment.recipient !== filters.recipient) {
+        return false
+      }
+
+      if (filters?.bounty_id && payment.bounty_id !== filters.bounty_id) {
+        return false
+      }
+
+      return true
+    })
   },
 }))

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -9,8 +9,24 @@ export const thingSchema = z.object({
 })
 export type Thing = z.infer<typeof thingSchema>
 
+export const paymentSchema = z.object({
+  payment_id: z.string(),
+  recipient: z.string(),
+  amount_usd: z.number().positive(),
+  currency: z.string(),
+  status: z.enum(["sent"]),
+  bounty_id: z.string().optional(),
+  issue_url: z.string().url().optional(),
+  memo: z.string().optional(),
+  idempotency_key: z.string().optional(),
+  transfer_reference: z.string(),
+  created_at: z.string(),
+})
+export type Payment = z.infer<typeof paymentSchema>
+
 export const databaseSchema = z.object({
   idCounter: z.number().default(0),
   things: z.array(thingSchema).default([]),
+  payments: z.array(paymentSchema).default([]),
 })
 export type DatabaseSchema = z.infer<typeof databaseSchema>

--- a/routes/payments/list.ts
+++ b/routes/payments/list.ts
@@ -1,0 +1,22 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  queryParams: z.object({
+    recipient: z.string().optional(),
+    bounty_id: z.string().optional(),
+  }),
+  jsonResponse: z.object({
+    payments: z.array(paymentSchema),
+  }),
+})((req, ctx) => {
+  const url = new URL(req.url)
+  const payments = ctx.db.listPayments({
+    recipient: url.searchParams.get("recipient") ?? undefined,
+    bounty_id: url.searchParams.get("bounty_id") ?? undefined,
+  })
+
+  return ctx.json({ payments })
+})

--- a/routes/payments/send.ts
+++ b/routes/payments/send.ts
@@ -1,0 +1,33 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: z.object({
+    recipient: z.string().min(1),
+    amount_usd: z.number().positive(),
+    currency: z.string().optional(),
+    bounty_id: z.string().optional(),
+    issue_url: z.string().url().optional(),
+    memo: z.string().optional(),
+    idempotency_key: z.string().min(1).optional(),
+  }),
+  jsonResponse: z.object({
+    payment: paymentSchema,
+    replayed: z.boolean(),
+  }),
+})(async (req, ctx) => {
+  const body = await req.json()
+  const result = ctx.db.sendPayment({
+    recipient: body.recipient,
+    amount_usd: body.amount_usd,
+    currency: body.currency ?? "USD",
+    bounty_id: body.bounty_id,
+    issue_url: body.issue_url,
+    memo: body.memo,
+    idempotency_key: body.idempotency_key,
+  })
+
+  return ctx.json(result)
+})

--- a/tests/routes/payments/send.test.ts
+++ b/tests/routes/payments/send.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("send a payment", async () => {
+  const { axios } = await getTestServer()
+
+  const { data } = await axios.post("/payments/send", {
+    recipient: "octocat",
+    amount_usd: 10,
+    bounty_id: "bounty_123",
+    issue_url: "https://github.com/tscircuit/fake-algora/issues/1",
+    memo: "Issue #1 bounty",
+  })
+
+  expect(data.replayed).toBe(false)
+  expect(data.payment.payment_id).toBe("pay_0")
+  expect(data.payment.recipient).toBe("octocat")
+  expect(data.payment.amount_usd).toBe(10)
+  expect(data.payment.currency).toBe("USD")
+  expect(data.payment.status).toBe("sent")
+  expect(data.payment.transfer_reference).toBe("fake_algora_0")
+  expect(data.payment.created_at).toBeDefined()
+})
+
+test("do not duplicate payments for the same idempotency key", async () => {
+  const { axios } = await getTestServer()
+
+  const body = {
+    recipient: "octocat",
+    amount_usd: 10,
+    idempotency_key: "issue-1-octocat",
+  }
+
+  const firstResponse = await axios.post("/payments/send", body)
+  const secondResponse = await axios.post("/payments/send", body)
+  const listResponse = await axios.get("/payments/list")
+
+  expect(firstResponse.data.replayed).toBe(false)
+  expect(secondResponse.data.replayed).toBe(true)
+  expect(secondResponse.data.payment.payment_id).toBe(
+    firstResponse.data.payment.payment_id,
+  )
+  expect(listResponse.data.payments).toHaveLength(1)
+})
+
+test("list sent payments by recipient and bounty", async () => {
+  const { axios } = await getTestServer()
+
+  await axios.post("/payments/send", {
+    recipient: "alice",
+    amount_usd: 5,
+    bounty_id: "bounty_a",
+  })
+
+  await axios.post("/payments/send", {
+    recipient: "bob",
+    amount_usd: 15,
+    bounty_id: "bounty_b",
+  })
+
+  const recipientResponse = await axios.get("/payments/list?recipient=alice")
+  const bountyResponse = await axios.get("/payments/list?bounty_id=bounty_b")
+
+  expect(recipientResponse.data.payments).toHaveLength(1)
+  expect(recipientResponse.data.payments[0].recipient).toBe("alice")
+  expect(bountyResponse.data.payments).toHaveLength(1)
+  expect(bountyResponse.data.payments[0].bounty_id).toBe("bounty_b")
+})


### PR DESCRIPTION
## Summary

- add a Winterspec-native `POST /payments/send` endpoint that records fake payment sends
- add `GET /payments/list` with recipient and bounty filters
- add idempotency-key handling so retrying the same send request returns the existing payment instead of duplicating it
- add regression tests for send, idempotency, and filtering

/claim #1

## Proof

- `bun test`
- `bun run build`
- `git diff --check`

Transparency: implementation was AI-assisted and locally verified.