### PR TITLE
Add fake payment API lifecycle

### DIFF
--- a/lib/db/db-client.ts
+++ b/lib/db/db-client.ts
@@ -1,9 +1,15 @@
-import { createStore, type StoreApi } from "zustand/vanilla"
+import { type HoistedStoreApi, hoist } from "zustand-hoist"
 import { immer } from "zustand/middleware/immer"
-import { hoist, type HoistedStoreApi } from "zustand-hoist"
+import { type StoreApi, createStore } from "zustand/vanilla"
 
-import { databaseSchema, type DatabaseSchema, type Thing } from "./schema.ts"
 import { combine } from "zustand/middleware"
+import {
+  type DatabaseSchema,
+  type Payment,
+  type PaymentStatus,
+  type Thing,
+  databaseSchema,
+} from "./schema.ts"
 
 export const createDatabase = () => {
   return hoist(createStore(initializer))
@@ -20,5 +26,59 @@ const initializer = combine(databaseSchema.parse({}), (set) => ({
       ],
       idCounter: state.idCounter + 1,
     }))
+  },
+  sendPayment: (
+    payment: Omit<
+      Payment,
+      "payment_id" | "status" | "created_at" | "updated_at"
+    >,
+  ) => {
+    let createdPayment: Payment | undefined
+    set((state) => {
+      if (payment.idempotency_key) {
+        const existingPayment = state.payments.find(
+          (existing) => existing.idempotency_key === payment.idempotency_key,
+        )
+        if (existingPayment) {
+          createdPayment = existingPayment
+          return state
+        }
+      }
+
+      const now = new Date().toISOString()
+      createdPayment = {
+        ...payment,
+        payment_id: `pay_${state.paymentIdCounter}`,
+        status: "pending",
+        created_at: now,
+        updated_at: now,
+      }
+
+      return {
+        payments: [...state.payments, createdPayment],
+        paymentIdCounter: state.paymentIdCounter + 1,
+      }
+    })
+
+    return createdPayment!
+  },
+  updatePaymentStatus: (payment_id: string, status: PaymentStatus) => {
+    let updatedPayment: Payment | undefined
+    set((state) => {
+      const now = new Date().toISOString()
+      const payments = state.payments.map((payment) => {
+        if (payment.payment_id !== payment_id) return payment
+        updatedPayment = {
+          ...payment,
+          status,
+          updated_at: now,
+        }
+        return updatedPayment
+      })
+
+      return { payments }
+    })
+
+    return updatedPayment
   },
 }))

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -9,8 +9,28 @@ export const thingSchema = z.object({
 })
 export type Thing = z.infer<typeof thingSchema>
 
+export const paymentStatusSchema = z.enum(["pending", "completed", "canceled"])
+export type PaymentStatus = z.infer<typeof paymentStatusSchema>
+
+export const paymentSchema = z.object({
+  payment_id: z.string(),
+  recipient: z.string(),
+  amount: z.number(),
+  currency: z.string(),
+  status: paymentStatusSchema,
+  bounty_id: z.string().optional(),
+  issue_number: z.number().optional(),
+  repository: z.string().optional(),
+  idempotency_key: z.string().optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+export type Payment = z.infer<typeof paymentSchema>
+
 export const databaseSchema = z.object({
   idCounter: z.number().default(0),
+  paymentIdCounter: z.number().default(0),
   things: z.array(thingSchema).default([]),
+  payments: z.array(paymentSchema).default([]),
 })
 export type DatabaseSchema = z.infer<typeof databaseSchema>

--- a/routes/payments/cancel.ts
+++ b/routes/payments/cancel.ts
@@ -1,0 +1,20 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const paymentIdBodySchema = z.object({
+  payment_id: z.string(),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: paymentIdBodySchema,
+  jsonResponse: z.object({
+    payment: paymentSchema.nullable(),
+  }),
+})(async (req, ctx) => {
+  const { payment_id } = await req.json()
+  const payment = ctx.db.updatePaymentStatus(payment_id, "canceled") ?? null
+
+  return ctx.json({ payment })
+})

--- a/routes/payments/complete.ts
+++ b/routes/payments/complete.ts
@@ -1,0 +1,20 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const paymentIdBodySchema = z.object({
+  payment_id: z.string(),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: paymentIdBodySchema,
+  jsonResponse: z.object({
+    payment: paymentSchema.nullable(),
+  }),
+})(async (req, ctx) => {
+  const { payment_id } = await req.json()
+  const payment = ctx.db.updatePaymentStatus(payment_id, "completed") ?? null
+
+  return ctx.json({ payment })
+})

--- a/routes/payments/get.ts
+++ b/routes/payments/get.ts
@@ -1,0 +1,16 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  jsonResponse: z.object({
+    payment: paymentSchema.nullable(),
+  }),
+})((req, ctx) => {
+  const payment_id = new URL(req.url).searchParams.get("payment_id")
+  const payment =
+    ctx.db.payments.find((item) => item.payment_id === payment_id) ?? null
+
+  return ctx.json({ payment })
+})

--- a/routes/payments/list.ts
+++ b/routes/payments/list.ts
@@ -1,0 +1,26 @@
+import { paymentSchema, paymentStatusSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  jsonResponse: z.object({
+    payments: z.array(paymentSchema),
+  }),
+})((req, ctx) => {
+  const searchParams = new URL(req.url).searchParams
+  const status = paymentStatusSchema
+    .optional()
+    .parse(searchParams.get("status") ?? undefined)
+  const recipient = searchParams.get("recipient") ?? undefined
+  const repository = searchParams.get("repository") ?? undefined
+
+  const payments = ctx.db.payments.filter((payment) => {
+    if (status && payment.status !== status) return false
+    if (recipient && payment.recipient !== recipient) return false
+    if (repository && payment.repository !== repository) return false
+    return true
+  })
+
+  return ctx.json({ payments })
+})

--- a/routes/payments/send.ts
+++ b/routes/payments/send.ts
@@ -1,0 +1,24 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const sendPaymentBodySchema = z.object({
+  recipient: z.string().min(1),
+  amount: z.number().positive(),
+  currency: z.string().min(1).default("USD"),
+  bounty_id: z.string().optional(),
+  issue_number: z.number().int().positive().optional(),
+  repository: z.string().optional(),
+  idempotency_key: z.string().optional(),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: sendPaymentBodySchema,
+  jsonResponse: z.object({
+    payment: paymentSchema,
+  }),
+})(async (req, ctx) => {
+  const payment = ctx.db.sendPayment(await req.json())
+  return ctx.json({ payment })
+})

--- a/tests/routes/payments/payments.test.ts
+++ b/tests/routes/payments/payments.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("payment lifecycle supports idempotent send, list, get, complete, and cancel", async () => {
+  const { axios } = await getTestServer()
+
+  const sendBody = {
+    recipient: "octocat",
+    amount: 10,
+    currency: "USD",
+    bounty_id: "bounty_1",
+    issue_number: 1,
+    repository: "tscircuit/fake-algora",
+    idempotency_key: "idem_1",
+  }
+
+  const firstSend = await axios.post("/payments/send", sendBody)
+  const retrySend = await axios.post("/payments/send", sendBody)
+
+  expect(firstSend.data.payment.payment_id).toBe(
+    retrySend.data.payment.payment_id,
+  )
+  expect(firstSend.data.payment.status).toBe("pending")
+
+  const listPending = await axios.get("/payments/list?status=pending")
+  expect(listPending.data.payments).toHaveLength(1)
+
+  const getPayment = await axios.get(
+    `/payments/get?payment_id=${firstSend.data.payment.payment_id}`,
+  )
+  expect(getPayment.data.payment.recipient).toBe("octocat")
+
+  const completePayment = await axios.post("/payments/complete", {
+    payment_id: firstSend.data.payment.payment_id,
+  })
+  expect(completePayment.data.payment.status).toBe("completed")
+
+  const cancelMissingPayment = await axios.post("/payments/cancel", {
+    payment_id: "missing",
+  })
+  expect(cancelMissingPayment.data.payment).toBeNull()
+})


### PR DESCRIPTION
Adds a Winterspec-native fake payment API for issue #1.

Implemented endpoints:
- POST /payments/send
- GET /payments/list
- GET /payments/get
- POST /payments/complete
- POST /payments/cancel

The send endpoint supports optional idempotency keys so retries return the original fake payment instead of creating duplicates. Payment records are persisted in the existing in-memory zod/zustand DB and can be filtered by status, recipient, or repository.

Verification:
- /private/tmp/bun-runtime/bun-darwin-aarch64/bun test
- /private/tmp/bun-runtime/bun-darwin-aarch64/bun x biome check lib/db/schema.ts lib/db/db-client.ts routes/payments/send.ts routes/payments/list.ts routes/payments/get.ts routes/payments/complete.ts routes/payments/cancel.ts tests/routes/payments/payments.test.ts
- /private/tmp/bun-runtime/bun-darwin-aarch64/bun run build

/claim #1