### PR TITLE
Add fake payment lifecycle API

### DIFF
--- a/lib/db/db-client.ts
+++ b/lib/db/db-client.ts
@@ -1,9 +1,15 @@
-import { createStore, type StoreApi } from "zustand/vanilla"
+import { type HoistedStoreApi, hoist } from "zustand-hoist"
 import { immer } from "zustand/middleware/immer"
-import { hoist, type HoistedStoreApi } from "zustand-hoist"
+import { type StoreApi, createStore } from "zustand/vanilla"
 
-import { databaseSchema, type DatabaseSchema, type Thing } from "./schema.ts"
 import { combine } from "zustand/middleware"
+import {
+  type DatabaseSchema,
+  type Payment,
+  type PaymentStatus,
+  type Thing,
+  databaseSchema,
+} from "./schema.ts"
 
 export const createDatabase = () => {
   return hoist(createStore(initializer))
@@ -20,5 +26,46 @@ const initializer = combine(databaseSchema.parse({}), (set) => ({
       ],
       idCounter: state.idCounter + 1,
     }))
+  },
+  createPayment: (
+    payment: Omit<
+      Payment,
+      "payment_id" | "status" | "created_at" | "updated_at"
+    >,
+  ) => {
+    let createdPayment: Payment
+    set((state) => {
+      const now = new Date().toISOString()
+      createdPayment = {
+        ...payment,
+        payment_id: `payment_${state.idCounter}`,
+        status: "pending",
+        created_at: now,
+        updated_at: now,
+      }
+      return {
+        payments: [...state.payments, createdPayment],
+        idCounter: state.idCounter + 1,
+      }
+    })
+    return createdPayment!
+  },
+  updatePaymentStatus: (paymentId: string, status: PaymentStatus) => {
+    let updatedPayment: Payment | undefined
+    set((state) => {
+      const now = new Date().toISOString()
+      return {
+        payments: state.payments.map((payment) => {
+          if (payment.payment_id !== paymentId) return payment
+          updatedPayment = {
+            ...payment,
+            status,
+            updated_at: now,
+          }
+          return updatedPayment
+        }),
+      }
+    })
+    return updatedPayment
   },
 }))

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -9,8 +9,32 @@ export const thingSchema = z.object({
 })
 export type Thing = z.infer<typeof thingSchema>
 
+export const paymentStatusSchema = z.enum([
+  "pending",
+  "completed",
+  "cancelled",
+  "failed",
+])
+export type PaymentStatus = z.infer<typeof paymentStatusSchema>
+
+export const paymentSchema = z.object({
+  payment_id: z.string(),
+  recipient: z.string(),
+  amount: z.number(),
+  currency: z.string(),
+  status: paymentStatusSchema,
+  bounty_id: z.string().optional(),
+  issue_number: z.number().optional(),
+  repository: z.string().optional(),
+  idempotency_key: z.string().optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+export type Payment = z.infer<typeof paymentSchema>
+
 export const databaseSchema = z.object({
   idCounter: z.number().default(0),
   things: z.array(thingSchema).default([]),
+  payments: z.array(paymentSchema).default([]),
 })
 export type DatabaseSchema = z.infer<typeof databaseSchema>

--- a/routes/payments/cancel.ts
+++ b/routes/payments/cancel.ts
@@ -1,0 +1,29 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const bodySchema = z.object({
+  payment_id: z.string(),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: bodySchema,
+  jsonResponse: z.union([
+    z.object({
+      payment: paymentSchema,
+    }),
+    z.object({
+      error: z.string(),
+    }),
+  ]),
+})(async (req, ctx) => {
+  const { payment_id } = bodySchema.parse(await req.json())
+  const payment = ctx.db.updatePaymentStatus(payment_id, "cancelled")
+
+  if (!payment) {
+    return ctx.json({ error: "Payment not found" }, { status: 404 })
+  }
+
+  return ctx.json({ payment })
+})

--- a/routes/payments/complete.ts
+++ b/routes/payments/complete.ts
@@ -1,0 +1,29 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const bodySchema = z.object({
+  payment_id: z.string(),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: bodySchema,
+  jsonResponse: z.union([
+    z.object({
+      payment: paymentSchema,
+    }),
+    z.object({
+      error: z.string(),
+    }),
+  ]),
+})(async (req, ctx) => {
+  const { payment_id } = bodySchema.parse(await req.json())
+  const payment = ctx.db.updatePaymentStatus(payment_id, "completed")
+
+  if (!payment) {
+    return ctx.json({ error: "Payment not found" }, { status: 404 })
+  }
+
+  return ctx.json({ payment })
+})

--- a/routes/payments/get.ts
+++ b/routes/payments/get.ts
@@ -1,0 +1,26 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  jsonResponse: z.union([
+    z.object({
+      payment: paymentSchema,
+    }),
+    z.object({
+      error: z.string(),
+    }),
+  ]),
+})((req, ctx) => {
+  const paymentId = new URL(req.url).searchParams.get("payment_id")
+  const payment = ctx.db.payments.find(
+    (candidate) => candidate.payment_id === paymentId,
+  )
+
+  if (!payment) {
+    return ctx.json({ error: "Payment not found" }, { status: 404 })
+  }
+
+  return ctx.json({ payment })
+})

--- a/routes/payments/list.ts
+++ b/routes/payments/list.ts
@@ -1,0 +1,26 @@
+import { paymentSchema, paymentStatusSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  jsonResponse: z.object({
+    payments: z.array(paymentSchema),
+  }),
+})((req, ctx) => {
+  const searchParams = new URL(req.url).searchParams
+  const status = paymentStatusSchema
+    .optional()
+    .parse(searchParams.get("status") ?? undefined)
+  const recipient = searchParams.get("recipient") ?? undefined
+  const repository = searchParams.get("repository") ?? undefined
+
+  const payments = ctx.db.payments.filter((payment) => {
+    if (status && payment.status !== status) return false
+    if (recipient && payment.recipient !== recipient) return false
+    if (repository && payment.repository !== repository) return false
+    return true
+  })
+
+  return ctx.json({ payments })
+})

--- a/routes/payments/send.ts
+++ b/routes/payments/send.ts
@@ -1,0 +1,33 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const paymentBodySchema = z.object({
+  recipient: z.string().min(1),
+  amount: z.number().positive(),
+  currency: z.string().min(1).default("USD"),
+  bounty_id: z.string().optional(),
+  issue_number: z.number().optional(),
+  repository: z.string().optional(),
+  idempotency_key: z.string().optional(),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: paymentBodySchema,
+  jsonResponse: z.object({
+    payment: paymentSchema,
+  }),
+})(async (req, ctx) => {
+  const body = paymentBodySchema.parse(await req.json())
+
+  if (body.idempotency_key) {
+    const existingPayment = ctx.db.payments.find(
+      (payment) => payment.idempotency_key === body.idempotency_key,
+    )
+    if (existingPayment) return ctx.json({ payment: existingPayment })
+  }
+
+  const payment = ctx.db.createPayment(body)
+  return ctx.json({ payment })
+})

--- a/tests/routes/payments/payments.test.ts
+++ b/tests/routes/payments/payments.test.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("creates, lists, and completes fake payments", async () => {
+  const { axios } = await getTestServer()
+
+  const sendResponse = await axios.post("/payments/send", {
+    recipient: "dev@example.com",
+    amount: 25,
+    currency: "USD",
+    bounty_id: "bounty_1",
+    issue_number: 1,
+    repository: "tscircuit/fake-algora",
+    idempotency_key: "retry-safe-payment",
+  })
+
+  expect(sendResponse.data.payment).toMatchObject({
+    recipient: "dev@example.com",
+    amount: 25,
+    currency: "USD",
+    status: "pending",
+    bounty_id: "bounty_1",
+    issue_number: 1,
+    repository: "tscircuit/fake-algora",
+    idempotency_key: "retry-safe-payment",
+  })
+
+  const duplicateSendResponse = await axios.post("/payments/send", {
+    recipient: "dev@example.com",
+    amount: 25,
+    currency: "USD",
+    idempotency_key: "retry-safe-payment",
+  })
+
+  expect(duplicateSendResponse.data.payment.payment_id).toBe(
+    sendResponse.data.payment.payment_id,
+  )
+
+  const listResponse = await axios.get(
+    "/payments/list?status=pending&repository=tscircuit/fake-algora",
+  )
+  expect(listResponse.data.payments).toHaveLength(1)
+
+  const getResponse = await axios.get(
+    `/payments/get?payment_id=${sendResponse.data.payment.payment_id}`,
+  )
+  expect(getResponse.data.payment.payment_id).toBe(
+    sendResponse.data.payment.payment_id,
+  )
+
+  const completeResponse = await axios.post("/payments/complete", {
+    payment_id: sendResponse.data.payment.payment_id,
+  })
+  expect(completeResponse.data.payment.status).toBe("completed")
+})
+
+test("cancels fake payments", async () => {
+  const { axios } = await getTestServer()
+
+  const sendResponse = await axios.post("/payments/send", {
+    recipient: "dev@example.com",
+    amount: 10,
+    currency: "USD",
+  })
+
+  const cancelResponse = await axios.post("/payments/cancel", {
+    payment_id: sendResponse.data.payment.payment_id,
+  })
+
+  expect(cancelResponse.data.payment.status).toBe("cancelled")
+})


### PR DESCRIPTION
## Summary
- Add in-memory fake payment records with recipient, amount, currency, bounty metadata, status, timestamps, and optional idempotency keys.
- Add send, list, get, complete, and cancel payment routes.
- Make send retry-safe when the same idempotency key is reused.
- Add route tests for create/list/get/complete and cancel flows.

/claim #1

## Verification
- bun test
- bunx tsc --noEmit
- bun run build
- bunx biome check lib/db/schema.ts lib/db/db-client.ts routes/payments tests/routes/payments
- git diff --check