### PR TITLE
Add fake payment API

### DIFF
--- a/lib/db/db-client.ts
+++ b/lib/db/db-client.ts
@@ -1,9 +1,15 @@
-import { createStore, type StoreApi } from "zustand/vanilla"
+import { type HoistedStoreApi, hoist } from "zustand-hoist"
 import { immer } from "zustand/middleware/immer"
-import { hoist, type HoistedStoreApi } from "zustand-hoist"
+import { type StoreApi, createStore } from "zustand/vanilla"
 
-import { databaseSchema, type DatabaseSchema, type Thing } from "./schema.ts"
 import { combine } from "zustand/middleware"
+import {
+  type DatabaseSchema,
+  type Payment,
+  type PaymentStatus,
+  type Thing,
+  databaseSchema,
+} from "./schema.ts"
 
 export const createDatabase = () => {
   return hoist(createStore(initializer))
@@ -11,7 +17,7 @@ export const createDatabase = () => {
 
 export type DbClient = ReturnType<typeof createDatabase>
 
-const initializer = combine(databaseSchema.parse({}), (set) => ({
+const initializer = combine(databaseSchema.parse({}), (set, get) => ({
   addThing: (thing: Omit<Thing, "thing_id">) => {
     set((state) => ({
       things: [
@@ -20,5 +26,57 @@ const initializer = combine(databaseSchema.parse({}), (set) => ({
       ],
       idCounter: state.idCounter + 1,
     }))
+  },
+  addPayment: (
+    payment: Omit<Payment, "payment_id" | "status" | "created_at">,
+  ) => {
+    const paymentId = `payment_${get().idCounter}`
+    const newPayment: Payment = {
+      ...payment,
+      payment_id: paymentId,
+      currency: payment.currency || "USD",
+      status: "pending",
+      created_at: new Date().toISOString(),
+    }
+
+    set((state) => ({
+      payments: [...state.payments, newPayment],
+      idCounter: state.idCounter + 1,
+    }))
+
+    return newPayment
+  },
+  findPaymentByIdempotencyKey: (idempotencyKey: string) => {
+    return get().payments.find(
+      (payment) => payment.idempotency_key === idempotencyKey,
+    )
+  },
+  listPayments: (filters: { status?: PaymentStatus; repository?: string }) => {
+    return get().payments.filter((payment) => {
+      if (filters.status && payment.status !== filters.status) return false
+      if (filters.repository && payment.repository !== filters.repository) {
+        return false
+      }
+      return true
+    })
+  },
+  completePayment: (paymentId: string) => {
+    let completedPayment: Payment | undefined
+    const completedAt = new Date().toISOString()
+
+    set((state) => ({
+      payments: state.payments.map((payment) => {
+        if (payment.payment_id !== paymentId) return payment
+
+        completedPayment = {
+          ...payment,
+          status: "completed",
+          completed_at: completedAt,
+        }
+        return completedPayment
+      }),
+    }))
+
+    return completedPayment
   },
 }))

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -9,8 +9,26 @@ export const thingSchema = z.object({
 })
 export type Thing = z.infer<typeof thingSchema>
 
+export const paymentStatusSchema = z.enum(["pending", "completed"])
+
+export const paymentSchema = z.object({
+  payment_id: z.string(),
+  recipient: z.string(),
+  amount: z.number(),
+  currency: z.string(),
+  repository: z.string().optional(),
+  issue_number: z.number().optional(),
+  idempotency_key: z.string().optional(),
+  status: paymentStatusSchema,
+  created_at: z.string(),
+  completed_at: z.string().optional(),
+})
+export type Payment = z.infer<typeof paymentSchema>
+export type PaymentStatus = z.infer<typeof paymentStatusSchema>
+
 export const databaseSchema = z.object({
   idCounter: z.number().default(0),
   things: z.array(thingSchema).default([]),
+  payments: z.array(paymentSchema).default([]),
 })
 export type DatabaseSchema = z.infer<typeof databaseSchema>

--- a/routes/payments/complete.ts
+++ b/routes/payments/complete.ts
@@ -1,0 +1,27 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: z.object({
+    payment_id: z.string(),
+  }),
+  jsonResponse: z.union([
+    z.object({
+      payment: paymentSchema,
+    }),
+    z.object({
+      error: z.string(),
+    }),
+  ]),
+})(async (req, ctx) => {
+  const { payment_id } = await req.json()
+  const payment = ctx.db.completePayment(payment_id)
+
+  if (!payment) {
+    return ctx.json({ error: "Payment not found" }, { status: 404 })
+  }
+
+  return ctx.json({ payment })
+})

--- a/routes/payments/list.ts
+++ b/routes/payments/list.ts
@@ -1,0 +1,28 @@
+import {
+  type PaymentStatus,
+  paymentSchema,
+  paymentStatusSchema,
+} from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  jsonResponse: z.object({
+    payments: z.array(paymentSchema),
+  }),
+})((req, ctx) => {
+  const params = new URL(req.url).searchParams
+  const status = params.get("status")
+  const repository = params.get("repository") ?? undefined
+
+  const filters: { status?: PaymentStatus; repository?: string } = {
+    repository,
+  }
+
+  if (status) {
+    filters.status = paymentStatusSchema.parse(status)
+  }
+
+  return ctx.json({ payments: ctx.db.listPayments(filters) })
+})

--- a/routes/payments/send.ts
+++ b/routes/payments/send.ts
@@ -1,0 +1,33 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: z.object({
+    recipient: z.string(),
+    amount: z.number().positive(),
+    currency: z.string().default("USD"),
+    repository: z.string().optional(),
+    issue_number: z.number().optional(),
+    idempotency_key: z.string().optional(),
+  }),
+  jsonResponse: z.object({
+    payment: paymentSchema,
+  }),
+})(async (req, ctx) => {
+  const paymentRequest = await req.json()
+
+  if (paymentRequest.idempotency_key) {
+    const existingPayment = ctx.db.findPaymentByIdempotencyKey(
+      paymentRequest.idempotency_key,
+    )
+    if (existingPayment) {
+      return ctx.json({ payment: existingPayment })
+    }
+  }
+
+  const payment = ctx.db.addPayment(paymentRequest)
+
+  return ctx.json({ payment })
+})

--- a/tests/routes/payments.test.ts
+++ b/tests/routes/payments.test.ts
@@ -1,0 +1,95 @@
+import { expect, it } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+it("POST /payments/send creates a pending payment", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.post("/payments/send", {
+    recipient: "alice@example.com",
+    amount: 1250,
+    currency: "USD",
+    repository: "tscircuit/fake-algora",
+    issue_number: 1,
+    idempotency_key: "claim-1-payment",
+  })
+
+  expect(res.status).toBe(200)
+  expect(res.data.payment).toMatchObject({
+    recipient: "alice@example.com",
+    amount: 1250,
+    currency: "USD",
+    repository: "tscircuit/fake-algora",
+    issue_number: 1,
+    idempotency_key: "claim-1-payment",
+    status: "pending",
+  })
+  expect(res.data.payment.payment_id).toBeTruthy()
+  expect(res.data.payment.created_at).toBeTruthy()
+})
+
+it("POST /payments/send returns the existing payment for the same idempotency key", async () => {
+  const { axios } = await getTestServer()
+
+  const firstRes = await axios.post("/payments/send", {
+    recipient: "alice@example.com",
+    amount: 1250,
+    idempotency_key: "same-payment",
+  })
+  const secondRes = await axios.post("/payments/send", {
+    recipient: "alice@example.com",
+    amount: 1250,
+    idempotency_key: "same-payment",
+  })
+
+  expect(secondRes.data.payment.payment_id).toBe(
+    firstRes.data.payment.payment_id,
+  )
+})
+
+it("GET /payments/list filters payments by status and repository", async () => {
+  const { axios } = await getTestServer()
+
+  await axios.post("/payments/send", {
+    recipient: "alice@example.com",
+    amount: 1250,
+    repository: "tscircuit/fake-algora",
+  })
+  await axios.post("/payments/send", {
+    recipient: "bob@example.com",
+    amount: 500,
+    repository: "tscircuit/other",
+  })
+
+  const res = await axios.get(
+    "/payments/list?status=pending&repository=tscircuit/fake-algora",
+  )
+
+  expect(res.status).toBe(200)
+  expect(res.data.payments).toHaveLength(1)
+  expect(res.data.payments[0]).toMatchObject({
+    recipient: "alice@example.com",
+    repository: "tscircuit/fake-algora",
+    status: "pending",
+  })
+})
+
+it("POST /payments/complete marks a pending payment as completed", async () => {
+  const { axios } = await getTestServer()
+
+  const sendRes = await axios.post("/payments/send", {
+    recipient: "alice@example.com",
+    amount: 1250,
+  })
+  const paymentId = sendRes.data.payment.payment_id
+
+  const completeRes = await axios.post("/payments/complete", {
+    payment_id: paymentId,
+  })
+
+  expect(completeRes.status).toBe(200)
+  expect(completeRes.data.payment).toMatchObject({
+    payment_id: paymentId,
+    status: "completed",
+  })
+  expect(completeRes.data.payment.completed_at).toBeTruthy()
+})


### PR DESCRIPTION
## Summary

- add an in-memory payment schema and payment store helpers
- add `POST /payments/send`, `GET /payments/list`, and `POST /payments/complete`
- cover payment creation, idempotent resend, filtered listing, and completion in route tests

## Testing

- `npm exec --yes bun -- test`
- `npx biome check lib/db/schema.ts lib/db/db-client.ts routes/payments/send.ts routes/payments/list.ts routes/payments/complete.ts tests/routes/payments.test.ts`
- `npm run build`
- `npx tsc --noEmit`

/claim #1
