### PR TITLE
Add fake payment lifecycle API

### DIFF
--- a/lib/db/db-client.ts
+++ b/lib/db/db-client.ts
@@ -1,9 +1,14 @@
-import { createStore, type StoreApi } from "zustand/vanilla"
+import { type HoistedStoreApi, hoist } from "zustand-hoist"
 import { immer } from "zustand/middleware/immer"
-import { hoist, type HoistedStoreApi } from "zustand-hoist"
+import { type StoreApi, createStore } from "zustand/vanilla"
 
-import { databaseSchema, type DatabaseSchema, type Thing } from "./schema.ts"
 import { combine } from "zustand/middleware"
+import {
+  type Payment,
+  type PaymentStatus,
+  type Thing,
+  databaseSchema,
+} from "./schema.ts"
 
 export const createDatabase = () => {
   return hoist(createStore(initializer))
@@ -20,5 +25,65 @@ const initializer = combine(databaseSchema.parse({}), (set) => ({
       ],
       idCounter: state.idCounter + 1,
     }))
+  },
+  addPayment: (
+    payment: Omit<
+      Payment,
+      | "payment_id"
+      | "status"
+      | "created_at"
+      | "updated_at"
+      | "completed_at"
+      | "cancelled_at"
+    >,
+  ) => {
+    let createdPayment: Payment | undefined
+
+    set((state) => {
+      const now = new Date().toISOString()
+      createdPayment = {
+        ...payment,
+        payment_id: state.paymentIdCounter.toString(),
+        status: "pending",
+        created_at: now,
+        updated_at: now,
+      }
+
+      return {
+        payments: [...state.payments, createdPayment],
+        paymentIdCounter: state.paymentIdCounter + 1,
+      }
+    })
+
+    if (!createdPayment) {
+      throw new Error("Payment was not created")
+    }
+
+    return createdPayment
+  },
+  updatePaymentStatus: (payment_id: string, status: PaymentStatus) => {
+    let updatedPayment: Payment | undefined
+
+    set((state) => {
+      const now = new Date().toISOString()
+
+      return {
+        payments: state.payments.map((payment) => {
+          if (payment.payment_id !== payment_id) return payment
+
+          updatedPayment = {
+            ...payment,
+            status,
+            updated_at: now,
+            ...(status === "completed" ? { completed_at: now } : {}),
+            ...(status === "cancelled" ? { cancelled_at: now } : {}),
+          }
+
+          return updatedPayment
+        }),
+      }
+    })
+
+    return updatedPayment
   },
 }))

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -9,8 +9,30 @@ export const thingSchema = z.object({
 })
 export type Thing = z.infer<typeof thingSchema>
 
+export const paymentStatusSchema = z.enum(["pending", "completed", "cancelled"])
+export type PaymentStatus = z.infer<typeof paymentStatusSchema>
+
+export const paymentSchema = z.object({
+  payment_id: z.string(),
+  recipient: z.string(),
+  amount: z.number(),
+  currency: z.string(),
+  status: paymentStatusSchema,
+  bounty_id: z.string().optional(),
+  issue_number: z.number().optional(),
+  repository: z.string().optional(),
+  idempotency_key: z.string().optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  completed_at: z.string().optional(),
+  cancelled_at: z.string().optional(),
+})
+export type Payment = z.infer<typeof paymentSchema>
+
 export const databaseSchema = z.object({
   idCounter: z.number().default(0),
+  paymentIdCounter: z.number().default(0),
   things: z.array(thingSchema).default([]),
+  payments: z.array(paymentSchema).default([]),
 })
 export type DatabaseSchema = z.infer<typeof databaseSchema>

--- a/lib/payments/schemas.ts
+++ b/lib/payments/schemas.ts
@@ -1,0 +1,34 @@
+import { paymentSchema, paymentStatusSchema } from "lib/db/schema"
+import { z } from "zod"
+
+export const sendPaymentBodySchema = z.object({
+  recipient: z.string().min(1),
+  amount: z.number().positive(),
+  currency: z.string().min(1).default("USD"),
+  bounty_id: z.string().min(1).optional(),
+  issue_number: z.number().int().positive().optional(),
+  repository: z.string().min(1).optional(),
+  idempotency_key: z.string().min(1).optional(),
+})
+
+export const paymentResponseSchema = z.object({
+  ok: z.boolean(),
+  payment: paymentSchema.optional(),
+  error: z.string().optional(),
+})
+
+export const paymentListResponseSchema = z.object({
+  ok: z.boolean(),
+  payments: z.array(paymentSchema),
+  error: z.string().optional(),
+})
+
+export const paymentQuerySchema = z.object({
+  status: paymentStatusSchema.optional(),
+  recipient: z.string().min(1).optional(),
+  repository: z.string().min(1).optional(),
+})
+
+export const paymentIdBodySchema = z.object({
+  payment_id: z.string().min(1),
+})

--- a/routes/payments/cancel.ts
+++ b/routes/payments/cancel.ts
@@ -1,0 +1,29 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import {
+  paymentIdBodySchema,
+  paymentResponseSchema,
+} from "lib/payments/schemas"
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: paymentIdBodySchema,
+  jsonResponse: paymentResponseSchema,
+})(async (req, ctx) => {
+  const { payment_id } = paymentIdBodySchema.parse(await req.json())
+  const payment = ctx.db.payments.find(
+    (candidate) => candidate.payment_id === payment_id,
+  )
+
+  if (!payment) {
+    return ctx.json({ ok: false, error: "payment_not_found" })
+  }
+
+  if (payment.status !== "pending") {
+    return ctx.json({ ok: false, error: "payment_not_pending" })
+  }
+
+  return ctx.json({
+    ok: true,
+    payment: ctx.db.updatePaymentStatus(payment_id, "cancelled"),
+  })
+})

--- a/routes/payments/complete.ts
+++ b/routes/payments/complete.ts
@@ -1,0 +1,29 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import {
+  paymentIdBodySchema,
+  paymentResponseSchema,
+} from "lib/payments/schemas"
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: paymentIdBodySchema,
+  jsonResponse: paymentResponseSchema,
+})(async (req, ctx) => {
+  const { payment_id } = paymentIdBodySchema.parse(await req.json())
+  const payment = ctx.db.payments.find(
+    (candidate) => candidate.payment_id === payment_id,
+  )
+
+  if (!payment) {
+    return ctx.json({ ok: false, error: "payment_not_found" })
+  }
+
+  if (payment.status !== "pending") {
+    return ctx.json({ ok: false, error: "payment_not_pending" })
+  }
+
+  return ctx.json({
+    ok: true,
+    payment: ctx.db.updatePaymentStatus(payment_id, "completed"),
+  })
+})

--- a/routes/payments/get.ts
+++ b/routes/payments/get.ts
@@ -1,0 +1,19 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { paymentResponseSchema } from "lib/payments/schemas"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  jsonResponse: paymentResponseSchema,
+})((req, ctx) => {
+  const url = new URL(req.url)
+  const payment_id = url.searchParams.get("payment_id")
+  const payment = ctx.db.payments.find(
+    (candidate) => candidate.payment_id === payment_id,
+  )
+
+  if (!payment) {
+    return ctx.json({ ok: false, error: "payment_not_found" })
+  }
+
+  return ctx.json({ ok: true, payment })
+})

--- a/routes/payments/list.ts
+++ b/routes/payments/list.ts
@@ -1,0 +1,27 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import {
+  paymentListResponseSchema,
+  paymentQuerySchema,
+} from "lib/payments/schemas"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  jsonResponse: paymentListResponseSchema,
+})(async (req, ctx) => {
+  const url = new URL(req.url)
+  const query = paymentQuerySchema.parse({
+    status: url.searchParams.get("status") ?? undefined,
+    recipient: url.searchParams.get("recipient") ?? undefined,
+    repository: url.searchParams.get("repository") ?? undefined,
+  })
+
+  const payments = ctx.db.payments.filter((payment) => {
+    if (query.status && payment.status !== query.status) return false
+    if (query.recipient && payment.recipient !== query.recipient) return false
+    if (query.repository && payment.repository !== query.repository)
+      return false
+    return true
+  })
+
+  return ctx.json({ ok: true, payments })
+})

--- a/routes/payments/send.ts
+++ b/routes/payments/send.ts
@@ -1,0 +1,27 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import {
+  paymentResponseSchema,
+  sendPaymentBodySchema,
+} from "lib/payments/schemas"
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: sendPaymentBodySchema,
+  jsonResponse: paymentResponseSchema,
+})(async (req, ctx) => {
+  const input = sendPaymentBodySchema.parse(await req.json())
+
+  if (input.idempotency_key) {
+    const existingPayment = ctx.db.payments.find(
+      (payment) => payment.idempotency_key === input.idempotency_key,
+    )
+
+    if (existingPayment) {
+      return ctx.json({ ok: true, payment: existingPayment })
+    }
+  }
+
+  const payment = ctx.db.addPayment(input)
+
+  return ctx.json({ ok: true, payment })
+})

--- a/tests/routes/payments/lifecycle.test.ts
+++ b/tests/routes/payments/lifecycle.test.ts
@@ -1,0 +1,78 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("send, list, get, complete, and cancel fake payments", async () => {
+  const { axios } = await getTestServer()
+
+  const { data: created } = await axios.post("/payments/send", {
+    recipient: "octocat",
+    amount: 10,
+    currency: "USD",
+    repository: "tscircuit/fake-algora",
+    issue_number: 1,
+    bounty_id: "issue-1",
+    idempotency_key: "reward-issue-1-octocat",
+  })
+
+  expect(created.ok).toBe(true)
+  expect(created.payment.payment_id).toBe("0")
+  expect(created.payment.status).toBe("pending")
+
+  const { data: repeated } = await axios.post("/payments/send", {
+    recipient: "octocat",
+    amount: 10,
+    currency: "USD",
+    idempotency_key: "reward-issue-1-octocat",
+  })
+
+  expect(repeated.payment.payment_id).toBe(created.payment.payment_id)
+
+  const { data: pendingList } = await axios.get(
+    "/payments/list?status=pending&repository=tscircuit/fake-algora",
+  )
+
+  expect(pendingList.payments).toHaveLength(1)
+  expect(pendingList.payments[0].recipient).toBe("octocat")
+
+  const { data: fetched } = await axios.get(
+    `/payments/get?payment_id=${created.payment.payment_id}`,
+  )
+
+  expect(fetched.payment.repository).toBe("tscircuit/fake-algora")
+
+  const { data: completed } = await axios.post("/payments/complete", {
+    payment_id: created.payment.payment_id,
+  })
+
+  expect(completed.ok).toBe(true)
+  expect(completed.payment.status).toBe("completed")
+  expect(completed.payment.completed_at).toBeString()
+
+  const { data: rejectedCancel } = await axios.post("/payments/cancel", {
+    payment_id: created.payment.payment_id,
+  })
+
+  expect(rejectedCancel).toEqual({
+    ok: false,
+    error: "payment_not_pending",
+  })
+})
+
+test("cancel keeps completed payments out of pending lists", async () => {
+  const { axios } = await getTestServer()
+
+  const { data: created } = await axios.post("/payments/send", {
+    recipient: "maintainer",
+    amount: 25,
+  })
+
+  const { data: cancelled } = await axios.post("/payments/cancel", {
+    payment_id: created.payment.payment_id,
+  })
+
+  expect(cancelled.payment.status).toBe("cancelled")
+  expect(cancelled.payment.cancelled_at).toBeString()
+
+  const { data: pendingList } = await axios.get("/payments/list?status=pending")
+  expect(pendingList.payments).toHaveLength(0)
+})


### PR DESCRIPTION
## Summary
- adds a Winterspec-native fake payment API for sending, listing, fetching, completing, and cancelling payments
- stores fake payments in the existing in-memory DB with status timestamps and bounty metadata
- makes send retry-safe when callers provide an idempotency key

## Verification
- bun x biome check lib\\db\\schema.ts lib\\db\\db-client.ts lib\\payments\\schemas.ts routes\\payments tests\\routes\\payments
- bun test
- bun run build
- bun x tsc --noEmit
- git diff --check

/claim #1