### PR TITLE
Add payment sending API

### DIFF
--- a/lib/db/db-client.ts
+++ b/lib/db/db-client.ts
@@ -2,7 +2,12 @@ import { createStore, type StoreApi } from "zustand/vanilla"
 import { immer } from "zustand/middleware/immer"
 import { hoist, type HoistedStoreApi } from "zustand-hoist"
 
-import { databaseSchema, type DatabaseSchema, type Thing } from "./schema.ts"
+import {
+  databaseSchema,
+  type DatabaseSchema,
+  type Payment,
+  type Thing,
+} from "./schema.ts"
 import { combine } from "zustand/middleware"
 
 export const createDatabase = () => {
@@ -20,5 +25,24 @@ const initializer = combine(databaseSchema.parse({}), (set) => ({
       ],
       idCounter: state.idCounter + 1,
     }))
+  },
+  sendPayment: (payment: Omit<Payment, "payment_id" | "status" | "created_at">) => {
+    let createdPayment: Payment | undefined
+
+    set((state) => {
+      createdPayment = {
+        ...payment,
+        payment_id: state.paymentCounter.toString(),
+        status: "sent",
+        created_at: new Date().toISOString(),
+      }
+
+      return {
+        payments: [...state.payments, createdPayment],
+        paymentCounter: state.paymentCounter + 1,
+      }
+    })
+
+    return createdPayment!
   },
 }))

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -9,8 +9,20 @@ export const thingSchema = z.object({
 })
 export type Thing = z.infer<typeof thingSchema>
 
+export const paymentSchema = z.object({
+  payment_id: z.string(),
+  recipient: z.string(),
+  amount_usd: z.number(),
+  memo: z.string().optional(),
+  status: z.enum(["sent"]),
+  created_at: z.string(),
+})
+export type Payment = z.infer<typeof paymentSchema>
+
 export const databaseSchema = z.object({
   idCounter: z.number().default(0),
   things: z.array(thingSchema).default([]),
+  paymentCounter: z.number().default(0),
+  payments: z.array(paymentSchema).default([]),
 })
 export type DatabaseSchema = z.infer<typeof databaseSchema>

--- a/routes/payments/list.ts
+++ b/routes/payments/list.ts
@@ -1,0 +1,12 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { paymentSchema } from "lib/db/schema"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  jsonResponse: z.object({
+    payments: z.array(paymentSchema),
+  }),
+})((req, ctx) => {
+  return ctx.json({ payments: ctx.db.payments })
+})

--- a/routes/payments/send.ts
+++ b/routes/payments/send.ts
@@ -1,0 +1,21 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { paymentSchema } from "lib/db/schema"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: z.object({
+    recipient: z.string().min(1),
+    amount_usd: z.number().positive(),
+    memo: z.string().optional(),
+  }),
+  jsonResponse: z.object({
+    ok: z.boolean(),
+    payment: paymentSchema,
+  }),
+})(async (req, ctx) => {
+  const paymentRequest = await req.json()
+  const payment = ctx.db.sendPayment(paymentRequest)
+
+  return ctx.json({ ok: true, payment })
+})

--- a/tests/routes/payments/send.test.ts
+++ b/tests/routes/payments/send.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("send and list payments", async () => {
+  const { axios } = await getTestServer()
+
+  const sendResponse = await axios.post("/payments/send", {
+    recipient: "maintainer@example.com",
+    amount_usd: 10,
+    memo: "Bounty payout",
+  })
+
+  expect(sendResponse.status).toBe(200)
+  expect(sendResponse.data.ok).toBe(true)
+  expect(sendResponse.data.payment).toMatchObject({
+    payment_id: "0",
+    recipient: "maintainer@example.com",
+    amount_usd: 10,
+    memo: "Bounty payout",
+    status: "sent",
+  })
+  expect(typeof sendResponse.data.payment.created_at).toBe("string")
+
+  const listResponse = await axios.get("/payments/list")
+
+  expect(listResponse.data.payments).toHaveLength(1)
+  expect(listResponse.data.payments[0]).toEqual(sendResponse.data.payment)
+})


### PR DESCRIPTION
Fixes #1.

Adds a small payment API bootstrap:
- POST /payments/send validates recipient, amount_usd, and optional memo, then records a sent payment.
- GET /payments/list returns recorded payments.
- Adds a payment schema and in-memory db helper.
- Adds coverage for sending and listing payments.

Verification:
- npx bun test
- npx bun run build