### PR TITLE
Add fake payment API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,11 @@ This is a template project with best-practice modules:
 - Winterspec for defining the API
 - bun testing
 - Zustand store with zod definition for database state
+
+## Fake Payments API
+
+- `POST /payments/send` creates a pending fake payment. It accepts `recipient`, `amount_usd`, optional `currency`, bounty metadata, and an optional `idempotency_key`.
+- `GET /payments/list` returns payments and can filter by `recipient`, `status`, `repository`, and `issue_number`.
+- `GET /payments/get?payment_id=payment_0` returns a single payment.
+- `POST /payments/complete` marks a payment as completed.
+- `POST /payments/cancel` marks a payment as cancelled.

--- a/lib/db/db-client.ts
+++ b/lib/db/db-client.ts
@@ -1,9 +1,20 @@
-import { createStore, type StoreApi } from "zustand/vanilla"
+import { type HoistedStoreApi, hoist } from "zustand-hoist"
 import { immer } from "zustand/middleware/immer"
-import { hoist, type HoistedStoreApi } from "zustand-hoist"
+import { type StoreApi, createStore } from "zustand/vanilla"
 
-import { databaseSchema, type DatabaseSchema, type Thing } from "./schema.ts"
 import { combine } from "zustand/middleware"
+import {
+  type DatabaseSchema,
+  type Payment,
+  type PaymentStatus,
+  type Thing,
+  databaseSchema,
+} from "./schema.ts"
+
+type PaymentInput = Omit<
+  Payment,
+  "payment_id" | "status" | "created_at" | "updated_at"
+>
 
 export const createDatabase = () => {
   return hoist(createStore(initializer))
@@ -11,7 +22,7 @@ export const createDatabase = () => {
 
 export type DbClient = ReturnType<typeof createDatabase>
 
-const initializer = combine(databaseSchema.parse({}), (set) => ({
+const initializer = combine(databaseSchema.parse({}), (set, get) => ({
   addThing: (thing: Omit<Thing, "thing_id">) => {
     set((state) => ({
       things: [
@@ -20,5 +31,60 @@ const initializer = combine(databaseSchema.parse({}), (set) => ({
       ],
       idCounter: state.idCounter + 1,
     }))
+  },
+  sendPayment: (
+    paymentInput: PaymentInput,
+  ): { payment: Payment; created: boolean } => {
+    const existingPayment = paymentInput.idempotency_key
+      ? get().payments.find(
+          (payment) => payment.idempotency_key === paymentInput.idempotency_key,
+        )
+      : undefined
+
+    if (existingPayment) {
+      return { payment: existingPayment, created: false }
+    }
+
+    const now = new Date().toISOString()
+    const payment: Payment = {
+      ...paymentInput,
+      payment_id: `payment_${get().paymentIdCounter}`,
+      status: "pending",
+      created_at: now,
+      updated_at: now,
+    }
+
+    set((state) => ({
+      payments: [...state.payments, payment],
+      paymentIdCounter: state.paymentIdCounter + 1,
+    }))
+
+    return { payment, created: true }
+  },
+  updatePaymentStatus: (
+    payment_id: string,
+    status: PaymentStatus,
+  ): Payment | undefined => {
+    const existingPayment = get().payments.find(
+      (payment) => payment.payment_id === payment_id,
+    )
+
+    if (!existingPayment) {
+      return undefined
+    }
+
+    const updatedPayment = {
+      ...existingPayment,
+      status,
+      updated_at: new Date().toISOString(),
+    }
+
+    set((state) => ({
+      payments: state.payments.map((payment) =>
+        payment.payment_id === payment_id ? updatedPayment : payment,
+      ),
+    }))
+
+    return updatedPayment
   },
 }))

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -9,8 +9,29 @@ export const thingSchema = z.object({
 })
 export type Thing = z.infer<typeof thingSchema>
 
+export const paymentStatusSchema = z.enum(["pending", "completed", "cancelled"])
+export type PaymentStatus = z.infer<typeof paymentStatusSchema>
+
+export const paymentSchema = z.object({
+  payment_id: z.string(),
+  recipient: z.string(),
+  amount_usd: z.number(),
+  currency: z.string(),
+  status: paymentStatusSchema,
+  memo: z.string().optional(),
+  bounty_id: z.string().optional(),
+  repository: z.string().optional(),
+  issue_number: z.number().optional(),
+  idempotency_key: z.string().optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+export type Payment = z.infer<typeof paymentSchema>
+
 export const databaseSchema = z.object({
   idCounter: z.number().default(0),
+  paymentIdCounter: z.number().default(0),
   things: z.array(thingSchema).default([]),
+  payments: z.array(paymentSchema).default([]),
 })
 export type DatabaseSchema = z.infer<typeof databaseSchema>

--- a/routes/payments/cancel.ts
+++ b/routes/payments/cancel.ts
@@ -1,0 +1,20 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const paymentTransitionBodySchema = z.object({
+  payment_id: z.string().min(1),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: paymentTransitionBodySchema,
+  jsonResponse: z.object({
+    payment: paymentSchema.optional(),
+  }),
+})(async (req, ctx) => {
+  const { payment_id } = paymentTransitionBodySchema.parse(await req.json())
+  const payment = ctx.db.updatePaymentStatus(payment_id, "cancelled")
+
+  return ctx.json({ payment })
+})

--- a/routes/payments/complete.ts
+++ b/routes/payments/complete.ts
@@ -1,0 +1,20 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const paymentTransitionBodySchema = z.object({
+  payment_id: z.string().min(1),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: paymentTransitionBodySchema,
+  jsonResponse: z.object({
+    payment: paymentSchema.optional(),
+  }),
+})(async (req, ctx) => {
+  const { payment_id } = paymentTransitionBodySchema.parse(await req.json())
+  const payment = ctx.db.updatePaymentStatus(payment_id, "completed")
+
+  return ctx.json({ payment })
+})

--- a/routes/payments/get.ts
+++ b/routes/payments/get.ts
@@ -1,0 +1,17 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  jsonResponse: z.object({
+    payment: paymentSchema.optional(),
+  }),
+})((req, ctx) => {
+  const paymentId = new URL(req.url).searchParams.get("payment_id")
+  const payment = ctx.db.payments.find(
+    (payment) => payment.payment_id === paymentId,
+  )
+
+  return ctx.json({ payment })
+})

--- a/routes/payments/list.ts
+++ b/routes/payments/list.ts
@@ -1,0 +1,28 @@
+import { paymentSchema, paymentStatusSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  jsonResponse: z.object({
+    payments: z.array(paymentSchema),
+  }),
+})((req, ctx) => {
+  const searchParams = new URL(req.url).searchParams
+  const recipient = searchParams.get("recipient")
+  const repository = searchParams.get("repository")
+  const issueNumber = searchParams.get("issue_number")
+  const status = paymentStatusSchema.safeParse(searchParams.get("status"))
+
+  const payments = ctx.db.payments.filter((payment) => {
+    if (recipient && payment.recipient !== recipient) return false
+    if (repository && payment.repository !== repository) return false
+    if (issueNumber && payment.issue_number !== Number(issueNumber))
+      return false
+    if (status.success && payment.status !== status.data) return false
+
+    return true
+  })
+
+  return ctx.json({ payments })
+})

--- a/routes/payments/send.ts
+++ b/routes/payments/send.ts
@@ -1,0 +1,28 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const sendPaymentBodySchema = z.object({
+  recipient: z.string().min(1),
+  amount_usd: z.number().positive(),
+  currency: z.string().min(1).default("USD"),
+  memo: z.string().optional(),
+  bounty_id: z.string().optional(),
+  repository: z.string().optional(),
+  issue_number: z.number().int().positive().optional(),
+  idempotency_key: z.string().min(1).optional(),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: sendPaymentBodySchema,
+  jsonResponse: z.object({
+    payment: paymentSchema,
+    created: z.boolean(),
+  }),
+})(async (req, ctx) => {
+  const body = sendPaymentBodySchema.parse(await req.json())
+  const result = ctx.db.sendPayment(body)
+
+  return ctx.json(result)
+})

--- a/tests/routes/payments.test.ts
+++ b/tests/routes/payments.test.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("send and list fake payments", async () => {
+  const { axios } = await getTestServer()
+
+  const { data: sendData } = await axios.post("/payments/send", {
+    recipient: "0x7bE8796529f13882430ECeAB807712039E0dAfA2",
+    amount_usd: 10,
+    memo: "Issue reward",
+    bounty_id: "bounty_1",
+    repository: "tscircuit/fake-algora",
+    issue_number: 1,
+  })
+
+  expect(sendData.created).toBe(true)
+  expect(sendData.payment).toMatchObject({
+    payment_id: "payment_0",
+    recipient: "0x7bE8796529f13882430ECeAB807712039E0dAfA2",
+    amount_usd: 10,
+    currency: "USD",
+    status: "pending",
+    bounty_id: "bounty_1",
+    repository: "tscircuit/fake-algora",
+    issue_number: 1,
+  })
+
+  const { data: listData } = await axios.get(
+    "/payments/list?repository=tscircuit/fake-algora&status=pending",
+  )
+  const { data: getData } = await axios.get(
+    `/payments/get?payment_id=${sendData.payment.payment_id}`,
+  )
+
+  expect(listData.payments).toHaveLength(1)
+  expect(listData.payments[0].payment_id).toBe("payment_0")
+  expect(getData.payment.payment_id).toBe("payment_0")
+})
+
+test("send payment is idempotent when an idempotency key is reused", async () => {
+  const { axios } = await getTestServer()
+
+  const requestBody = {
+    recipient: "6Da5nELroja5ngTwYZuofFur5V7gZCLvKVRX7iUahwz2",
+    amount_usd: 5,
+    idempotency_key: "reward-1",
+  }
+
+  const { data: firstSend } = await axios.post("/payments/send", requestBody)
+  const { data: secondSend } = await axios.post("/payments/send", requestBody)
+  const { data: listData } = await axios.get("/payments/list")
+
+  expect(firstSend.created).toBe(true)
+  expect(secondSend.created).toBe(false)
+  expect(secondSend.payment.payment_id).toBe(firstSend.payment.payment_id)
+  expect(listData.payments).toHaveLength(1)
+})
+
+test("complete and cancel payment records", async () => {
+  const { axios } = await getTestServer()
+
+  const { data: sendData } = await axios.post("/payments/send", {
+    recipient: "recipient@example.com",
+    amount_usd: 25,
+  })
+
+  const { data: completeData } = await axios.post("/payments/complete", {
+    payment_id: sendData.payment.payment_id,
+  })
+
+  expect(completeData.payment.status).toBe("completed")
+
+  const { data: secondSendData } = await axios.post("/payments/send", {
+    recipient: "cancel@example.com",
+    amount_usd: 15,
+  })
+
+  const { data: cancelData } = await axios.post("/payments/cancel", {
+    payment_id: secondSendData.payment.payment_id,
+  })
+
+  expect(cancelData.payment.status).toBe("cancelled")
+})


### PR DESCRIPTION
## Summary
/claim #1

- add in-memory fake payment records with pending/completed/cancelled statuses
- add Winterspec routes for send, list, get, complete, and cancel payment flows
- support idempotency keys so repeated send requests return the original payment
- add route coverage for listing/filtering, fetching, idempotent sends, completion, and cancellation
- document the fake payment endpoints in the README

Transparency: AI-assisted with Codex; I reviewed the diff and verification results.

## Verification
- `bun test tests/routes/payments.test.ts`
- `bun test`
- `bunx biome check lib/db/schema.ts lib/db/db-client.ts routes/payments tests/routes/payments.test.ts README.md`
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`