### PR TITLE
Add fake payment lifecycle API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,33 @@ This is a template project with best-practice modules:
 - Winterspec for defining the API
 - bun testing
 - Zustand store with zod definition for database state
+
+## Fake payment API
+
+The app exposes a small fake payment lifecycle API for testing bounty payout
+flows without moving real money.
+
+```bash
+curl -X POST http://localhost:3000/payments/send \
+  -H "Content-Type: application/json" \
+  -d '{
+    "recipient": "octocat",
+    "amount": 10,
+    "currency": "USD",
+    "bounty_id": "1",
+    "issue_number": 1,
+    "repository": "tscircuit/fake-algora",
+    "idempotency_key": "retry-safe-transfer"
+  }'
+```
+
+Available routes:
+
+- `POST /payments/send` creates a pending payment and reuses the existing
+  payment when the same `idempotency_key` is sent again.
+- `GET /payments/list` lists payments, optionally filtered by `recipient`,
+  `status`, `repository`, or `bounty_id`.
+- `GET /payments/get?payment_id=pay_0` returns one payment.
+- `POST /payments/complete` marks a payment as completed.
+- `POST /payments/cancel` marks a payment as cancelled.
+- `POST /payments/fail` marks a payment as failed with an optional `reason`.

--- a/lib/db/db-client.ts
+++ b/lib/db/db-client.ts
@@ -1,9 +1,35 @@
-import { createStore, type StoreApi } from "zustand/vanilla"
-import { immer } from "zustand/middleware/immer"
-import { hoist, type HoistedStoreApi } from "zustand-hoist"
-
-import { databaseSchema, type DatabaseSchema, type Thing } from "./schema.ts"
+import { hoist } from "zustand-hoist"
 import { combine } from "zustand/middleware"
+import { createStore } from "zustand/vanilla"
+import {
+  type Payment,
+  type PaymentStatus,
+  type Thing,
+  databaseSchema,
+} from "./schema.ts"
+
+export interface CreatePaymentInput {
+  recipient: string
+  amount: number
+  currency?: string
+  bounty_id?: string
+  issue_number?: number
+  repository?: string
+  idempotency_key?: string
+}
+
+export interface PaymentFilters {
+  recipient?: string
+  status?: PaymentStatus
+  repository?: string
+  bounty_id?: string
+}
+
+const terminalStatuses = new Set<PaymentStatus>([
+  "completed",
+  "cancelled",
+  "failed",
+])
 
 export const createDatabase = () => {
   return hoist(createStore(initializer))
@@ -11,7 +37,7 @@ export const createDatabase = () => {
 
 export type DbClient = ReturnType<typeof createDatabase>
 
-const initializer = combine(databaseSchema.parse({}), (set) => ({
+const initializer = combine(databaseSchema.parse({}), (set, dbGet) => ({
   addThing: (thing: Omit<Thing, "thing_id">) => {
     set((state) => ({
       things: [
@@ -20,5 +46,98 @@ const initializer = combine(databaseSchema.parse({}), (set) => ({
       ],
       idCounter: state.idCounter + 1,
     }))
+  },
+  createPayment: (input: CreatePaymentInput) => {
+    const existingPayment = input.idempotency_key
+      ? dbGet().payments.find(
+          (payment) => payment.idempotency_key === input.idempotency_key,
+        )
+      : undefined
+
+    if (existingPayment) {
+      return existingPayment
+    }
+
+    const now = new Date().toISOString()
+    const paymentId = `pay_${dbGet().paymentIdCounter}`
+    const payment: Payment = {
+      payment_id: paymentId,
+      recipient: input.recipient,
+      amount: input.amount,
+      currency: input.currency ?? "USD",
+      status: "pending",
+      bounty_id: input.bounty_id,
+      issue_number: input.issue_number,
+      repository: input.repository,
+      idempotency_key: input.idempotency_key,
+      created_at: now,
+      updated_at: now,
+    }
+
+    set((state) => ({
+      payments: [...state.payments, payment],
+      paymentIdCounter: state.paymentIdCounter + 1,
+    }))
+
+    return payment
+  },
+  getPayment: (paymentId: string) => {
+    return dbGet().payments.find((payment) => payment.payment_id === paymentId)
+  },
+  listPayments: (filters: PaymentFilters = {}) => {
+    return dbGet().payments.filter((payment) => {
+      if (filters.recipient && payment.recipient !== filters.recipient) {
+        return false
+      }
+      if (filters.status && payment.status !== filters.status) {
+        return false
+      }
+      if (filters.repository && payment.repository !== filters.repository) {
+        return false
+      }
+      if (filters.bounty_id && payment.bounty_id !== filters.bounty_id) {
+        return false
+      }
+      return true
+    })
+  },
+  updatePaymentStatus: (
+    paymentId: string,
+    status: Exclude<PaymentStatus, "pending">,
+    failureReason?: string,
+  ) => {
+    const payment = dbGet().payments.find(
+      (payment) => payment.payment_id === paymentId,
+    )
+
+    if (!payment) {
+      return undefined
+    }
+
+    if (terminalStatuses.has(payment.status) && payment.status !== status) {
+      return payment
+    }
+
+    const now = new Date().toISOString()
+    let updatedPayment: Payment | undefined
+
+    set((state) => ({
+      payments: state.payments.map((payment) => {
+        if (payment.payment_id !== paymentId) {
+          return payment
+        }
+
+        updatedPayment = {
+          ...payment,
+          status,
+          failure_reason: status === "failed" ? failureReason : undefined,
+          updated_at: now,
+        }
+
+        return updatedPayment
+      }),
+    }))
+
+    return updatedPayment
   },
 }))

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -9,8 +9,34 @@ export const thingSchema = z.object({
 })
 export type Thing = z.infer<typeof thingSchema>
 
+export const paymentStatusSchema = z.enum([
+  "pending",
+  "completed",
+  "cancelled",
+  "failed",
+])
+export type PaymentStatus = z.infer<typeof paymentStatusSchema>
+
+export const paymentSchema = z.object({
+  payment_id: z.string(),
+  recipient: z.string(),
+  amount: z.number(),
+  currency: z.string(),
+  status: paymentStatusSchema,
+  bounty_id: z.string().optional(),
+  issue_number: z.number().int().optional(),
+  repository: z.string().optional(),
+  idempotency_key: z.string().optional(),
+  failure_reason: z.string().optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+export type Payment = z.infer<typeof paymentSchema>
+
 export const databaseSchema = z.object({
   idCounter: z.number().default(0),
+  paymentIdCounter: z.number().default(0),
   things: z.array(thingSchema).default([]),
+  payments: z.array(paymentSchema).default([]),
 })
 export type DatabaseSchema = z.infer<typeof databaseSchema>

--- a/lib/payments/schemas.ts
+++ b/lib/payments/schemas.ts
@@ -1,0 +1,47 @@
+import { paymentSchema, paymentStatusSchema } from "lib/db/schema"
+import { z } from "zod"
+
+export const sendPaymentRequestSchema = z.object({
+  recipient: z.string().min(1),
+  amount: z.number().positive(),
+  currency: z.string().min(3).max(12).default("USD"),
+  bounty_id: z.string().min(1).optional(),
+  issue_number: z.number().int().positive().optional(),
+  repository: z.string().min(1).optional(),
+  idempotency_key: z.string().min(1).optional(),
+})
+
+export const paymentResponseSchema = z.object({
+  ok: z.literal(true),
+  payment: paymentSchema,
+})
+
+export const paymentListResponseSchema = z.object({
+  payments: z.array(paymentSchema),
+})
+
+export const paymentErrorResponseSchema = z.object({
+  ok: z.literal(false),
+  error: z.string(),
+})
+
+export const paymentResponseOrErrorSchema = z.union([
+  paymentResponseSchema,
+  paymentErrorResponseSchema,
+])
+
+export const paymentStatusTransitionRequestSchema = z.object({
+  payment_id: z.string().min(1),
+})
+
+export const failPaymentRequestSchema =
+  paymentStatusTransitionRequestSchema.extend({
+    reason: z.string().min(1).optional(),
+  })
+
+export const paymentListQuerySchema = z.object({
+  recipient: z.string().optional(),
+  status: paymentStatusSchema.optional(),
+  repository: z.string().optional(),
+  bounty_id: z.string().optional(),
+})

--- a/routes/payments/cancel.ts
+++ b/routes/payments/cancel.ts
@@ -1,0 +1,25 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import {
+  paymentResponseOrErrorSchema,
+  paymentStatusTransitionRequestSchema,
+} from "lib/payments/schemas"
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: paymentStatusTransitionRequestSchema,
+  jsonResponse: paymentResponseOrErrorSchema,
+})(async (req, ctx) => {
+  const { payment_id } = paymentStatusTransitionRequestSchema.parse(
+    await req.json(),
+  )
+  const payment = ctx.db.updatePaymentStatus(payment_id, "cancelled")
+
+  if (!payment) {
+    return ctx.json(
+      { ok: false, error: `Payment "${payment_id}" was not found` },
+      { status: 404 },
+    )
+  }
+
+  return ctx.json({ ok: true, payment })
+})

--- a/routes/payments/complete.ts
+++ b/routes/payments/complete.ts
@@ -1,0 +1,25 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import {
+  paymentResponseOrErrorSchema,
+  paymentStatusTransitionRequestSchema,
+} from "lib/payments/schemas"
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: paymentStatusTransitionRequestSchema,
+  jsonResponse: paymentResponseOrErrorSchema,
+})(async (req, ctx) => {
+  const { payment_id } = paymentStatusTransitionRequestSchema.parse(
+    await req.json(),
+  )
+  const payment = ctx.db.updatePaymentStatus(payment_id, "completed")
+
+  if (!payment) {
+    return ctx.json(
+      { ok: false, error: `Payment "${payment_id}" was not found` },
+      { status: 404 },
+    )
+  }
+
+  return ctx.json({ ok: true, payment })
+})

--- a/routes/payments/fail.ts
+++ b/routes/payments/fail.ts
@@ -1,0 +1,25 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import {
+  failPaymentRequestSchema,
+  paymentResponseOrErrorSchema,
+} from "lib/payments/schemas"
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: failPaymentRequestSchema,
+  jsonResponse: paymentResponseOrErrorSchema,
+})(async (req, ctx) => {
+  const { payment_id, reason } = failPaymentRequestSchema.parse(
+    await req.json(),
+  )
+  const payment = ctx.db.updatePaymentStatus(payment_id, "failed", reason)
+
+  if (!payment) {
+    return ctx.json(
+      { ok: false, error: `Payment "${payment_id}" was not found` },
+      { status: 404 },
+    )
+  }
+
+  return ctx.json({ ok: true, payment })
+})

--- a/routes/payments/get.ts
+++ b/routes/payments/get.ts
@@ -1,0 +1,25 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { paymentResponseOrErrorSchema } from "lib/payments/schemas"
+import { z } from "zod"
+
+const getPaymentQuerySchema = z.object({
+  payment_id: z.string().min(1),
+})
+
+export default withRouteSpec({
+  methods: ["GET"],
+  queryParams: getPaymentQuerySchema,
+  jsonResponse: paymentResponseOrErrorSchema,
+})((req, ctx) => {
+  const { payment_id } = getPaymentQuerySchema.parse(req.query)
+  const payment = ctx.db.getPayment(payment_id)
+
+  if (!payment) {
+    return ctx.json(
+      { ok: false, error: `Payment "${payment_id}" was not found` },
+      { status: 404 },
+    )
+  }
+
+  return ctx.json({ ok: true, payment })
+})

--- a/routes/payments/list.ts
+++ b/routes/payments/list.ts
@@ -1,0 +1,17 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import {
+  paymentListQuerySchema,
+  paymentListResponseSchema,
+} from "lib/payments/schemas"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  queryParams: paymentListQuerySchema,
+  jsonResponse: paymentListResponseSchema,
+})((req, ctx) => {
+  const filters = paymentListQuerySchema.parse(req.query)
+
+  return ctx.json({
+    payments: ctx.db.listPayments(filters),
+  })
+})

--- a/routes/payments/send.ts
+++ b/routes/payments/send.ts
@@ -1,0 +1,16 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import {
+  paymentResponseSchema,
+  sendPaymentRequestSchema,
+} from "lib/payments/schemas"
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: sendPaymentRequestSchema,
+  jsonResponse: paymentResponseSchema,
+})(async (req, ctx) => {
+  const paymentInput = sendPaymentRequestSchema.parse(await req.json())
+  const payment = ctx.db.createPayment(paymentInput)
+
+  return ctx.json({ ok: true, payment }, { status: 201 })
+})

--- a/tests/fixtures/get-test-server.ts
+++ b/tests/fixtures/get-test-server.ts
@@ -1,5 +1,4 @@
 import { afterEach } from "bun:test"
-import { tmpdir } from "node:os"
 import defaultAxios from "redaxios"
 import { startServer } from "./start-server"
 
@@ -10,16 +9,15 @@ interface TestFixture {
 }
 
 export const getTestServer = async (): Promise<TestFixture> => {
-  const port = 3001 + Math.floor(Math.random() * 999)
   const testInstanceId = Math.random().toString(36).substring(2, 15)
   const testDbName = `testdb${testInstanceId}`
 
   const server = await startServer({
-    port,
+    port: 0,
     testDbName,
   })
 
-  const url = `http://127.0.0.1:${port}`
+  const url = server.url.toString()
   const axios = defaultAxios.create({
     baseURL: url,
   })

--- a/tests/routes/payments/payments.test.ts
+++ b/tests/routes/payments/payments.test.ts
@@ -1,0 +1,115 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("sends and lists fake payments", async () => {
+  const { axios } = await getTestServer()
+
+  const { data, status } = await axios.post("/payments/send", {
+    recipient: "octocat",
+    amount: 10,
+    currency: "USD",
+    bounty_id: "1",
+    issue_number: 1,
+    repository: "tscircuit/fake-algora",
+  })
+
+  expect(status).toBe(201)
+  expect(data.payment).toMatchObject({
+    recipient: "octocat",
+    amount: 10,
+    currency: "USD",
+    status: "pending",
+    bounty_id: "1",
+    issue_number: 1,
+    repository: "tscircuit/fake-algora",
+  })
+
+  const listResponse = await axios.get("/payments/list?status=pending")
+
+  expect(listResponse.data.payments).toHaveLength(1)
+  expect(listResponse.data.payments[0].payment_id).toBe(data.payment.payment_id)
+})
+
+test("reuses an existing payment for the same idempotency key", async () => {
+  const { axios } = await getTestServer()
+
+  const first = await axios.post("/payments/send", {
+    recipient: "octocat",
+    amount: 10,
+    idempotency_key: "retry-safe-transfer",
+  })
+  const retry = await axios.post("/payments/send", {
+    recipient: "octocat",
+    amount: 10,
+    idempotency_key: "retry-safe-transfer",
+  })
+
+  expect(retry.data.payment.payment_id).toBe(first.data.payment.payment_id)
+
+  const listResponse = await axios.get("/payments/list")
+
+  expect(listResponse.data.payments).toHaveLength(1)
+})
+
+test("retrieves and completes a payment", async () => {
+  const { axios } = await getTestServer()
+
+  const sendResponse = await axios.post("/payments/send", {
+    recipient: "octocat",
+    amount: 10,
+  })
+  const paymentId = sendResponse.data.payment.payment_id
+
+  const getResponse = await axios.get(`/payments/get?payment_id=${paymentId}`)
+
+  expect(getResponse.data.payment.payment_id).toBe(paymentId)
+
+  const completeResponse = await axios.post("/payments/complete", {
+    payment_id: paymentId,
+  })
+
+  expect(completeResponse.data.payment.status).toBe("completed")
+  expect(completeResponse.data.payment.updated_at).not.toBe(
+    sendResponse.data.payment.updated_at,
+  )
+})
+
+test("cancels and fails payments", async () => {
+  const { axios } = await getTestServer()
+
+  const cancelTarget = await axios.post("/payments/send", {
+    recipient: "octocat",
+    amount: 10,
+  })
+  const failTarget = await axios.post("/payments/send", {
+    recipient: "hubot",
+    amount: 20,
+  })
+
+  const cancelled = await axios.post("/payments/cancel", {
+    payment_id: cancelTarget.data.payment.payment_id,
+  })
+  const failed = await axios.post("/payments/fail", {
+    payment_id: failTarget.data.payment.payment_id,
+    reason: "insufficient fake funds",
+  })
+
+  expect(cancelled.data.payment.status).toBe("cancelled")
+  expect(failed.data.payment.status).toBe("failed")
+  expect(failed.data.payment.failure_reason).toBe("insufficient fake funds")
+})
+
+test("returns 404 for missing payments", async () => {
+  const { axios } = await getTestServer()
+
+  try {
+    await axios.get("/payments/get?payment_id=pay_missing")
+    throw new Error("Expected request to fail")
+  } catch (error: any) {
+    expect(error.status).toBe(404)
+    expect(error.data).toEqual({
+      ok: false,
+      error: 'Payment "pay_missing" was not found',
+    })
+  }
+})


### PR DESCRIPTION
/claim #1

## Summary
- Add fake payment records to the in-memory database schema
- Add payment lifecycle routes: send, list, get, complete, cancel, and fail
- Support idempotency keys for retry-safe payment creation
- Add route tests for lifecycle, filtering, idempotency, and missing payments
- Document the fake payment API in the README

## Verification
- bun test
- bun run build
- bunx tsc --noEmit
- bunx biome check lib/db/schema.ts lib/db/db-client.ts lib/payments/schemas.ts routes/payments tests/routes/payments/payments.test.ts tests/fixtures/get-test-server.ts README.md
- git diff --check