### PR TITLE
Add payment lifecycle API with idempotent send support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ This is a template project with best-practice modules:
 
 - `POST /payments/send` - create a fake payment record
 - `GET /payments/list` - list fake payment records
+  - supports optional filters via query params: `recipient`, `bounty_issue`, `status`
 - `POST /payments/get` - fetch a payment by id
 - `POST /payments/complete` - mark a payment as completed
 - `POST /payments/cancel` - mark a payment as canceled
+
+## Payment Behavior
+
+- `POST /payments/send` supports optional `idempotency_key` so retries do not duplicate payments
+- status transitions are guarded:
+  - only `pending` payments can be completed or canceled
+  - non-pending transitions return `error: "invalid_status_transition"`

--- a/README.md
+++ b/README.md
@@ -4,3 +4,11 @@ This is a template project with best-practice modules:
 - Winterspec for defining the API
 - bun testing
 - Zustand store with zod definition for database state
+
+## Payment Routes
+
+- `POST /payments/send` - create a fake payment record
+- `GET /payments/list` - list fake payment records
+- `POST /payments/get` - fetch a payment by id
+- `POST /payments/complete` - mark a payment as completed
+- `POST /payments/cancel` - mark a payment as canceled

--- a/lib/db/db-client.ts
+++ b/lib/db/db-client.ts
@@ -2,7 +2,13 @@ import { createStore, type StoreApi } from "zustand/vanilla"
 import { immer } from "zustand/middleware/immer"
 import { hoist, type HoistedStoreApi } from "zustand-hoist"
 
-import { databaseSchema, type DatabaseSchema, type Thing } from "./schema.ts"
+import {
+  databaseSchema,
+  type DatabaseSchema,
+  type Payment,
+  type PaymentStatus,
+  type Thing,
+} from "./schema.ts"
 import { combine } from "zustand/middleware"
 
 export const createDatabase = () => {
@@ -11,7 +17,7 @@ export const createDatabase = () => {
 
 export type DbClient = ReturnType<typeof createDatabase>
 
-const initializer = combine(databaseSchema.parse({}), (set) => ({
+const initializer = combine(databaseSchema.parse({}), (set, get) => ({
   addThing: (thing: Omit<Thing, "thing_id">) => {
     set((state) => ({
       things: [
@@ -19,6 +25,46 @@ const initializer = combine(databaseSchema.parse({}), (set) => ({
         { ...thing, thing_id: state.idCounter.toString() },
       ],
       idCounter: state.idCounter + 1,
+    }))
+  },
+  addPayment: (
+    payment: Omit<
+      Payment,
+      "payment_id" | "status" | "created_at" | "updated_at" | "metadata"
+    > & {
+      metadata?: Record<string, string>
+    },
+  ) => {
+    const now = new Date().toISOString()
+    set((state) => ({
+      payments: [
+        ...state.payments,
+        {
+          ...payment,
+          payment_id: state.idCounter.toString(),
+          status: "pending",
+          metadata: payment.metadata ?? {},
+          created_at: now,
+          updated_at: now,
+        },
+      ],
+      idCounter: state.idCounter + 1,
+    }))
+  },
+  findPaymentById: (payment_id: string) => {
+    return get().payments.find((p) => p.payment_id === payment_id)
+  },
+  findPaymentByIdempotencyKey: (idempotency_key: string) => {
+    return get().payments.find((p) => p.idempotency_key === idempotency_key)
+  },
+  updatePaymentStatus: (payment_id: string, status: PaymentStatus) => {
+    const now = new Date().toISOString()
+    set((state) => ({
+      payments: state.payments.map((payment) =>
+        payment.payment_id === payment_id
+          ? { ...payment, status, updated_at: now }
+          : payment,
+      ),
     }))
   },
 }))

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -9,8 +9,31 @@ export const thingSchema = z.object({
 })
 export type Thing = z.infer<typeof thingSchema>
 
+export const paymentStatusSchema = z.enum([
+  "pending",
+  "completed",
+  "canceled",
+  "failed",
+])
+export type PaymentStatus = z.infer<typeof paymentStatusSchema>
+
+export const paymentSchema = z.object({
+  payment_id: z.string(),
+  recipient: z.string(),
+  amount: z.number().positive(),
+  currency: z.string().default("USD"),
+  status: paymentStatusSchema.default("pending"),
+  idempotency_key: z.string().optional(),
+  bounty_issue: z.string().optional(),
+  metadata: z.record(z.string(), z.string()).default({}),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+export type Payment = z.infer<typeof paymentSchema>
+
 export const databaseSchema = z.object({
   idCounter: z.number().default(0),
   things: z.array(thingSchema).default([]),
+  payments: z.array(paymentSchema).default([]),
 })
 export type DatabaseSchema = z.infer<typeof databaseSchema>

--- a/routes/payments/cancel.ts
+++ b/routes/payments/cancel.ts
@@ -1,0 +1,46 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const updatePaymentSchema = z.object({
+  payment_id: z.string().min(1),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: updatePaymentSchema,
+  jsonResponse: z.object({
+    ok: z.boolean(),
+    payment: z
+      .object({
+        payment_id: z.string(),
+        recipient: z.string(),
+        amount: z.number(),
+        currency: z.string(),
+        status: z.enum(["pending", "completed", "canceled", "failed"]),
+        idempotency_key: z.string().optional(),
+        bounty_issue: z.string().optional(),
+        metadata: z.record(z.string(), z.string()),
+        created_at: z.string(),
+        updated_at: z.string(),
+      })
+      .nullable(),
+    error: z.string().optional(),
+  }),
+})(async (req, ctx) => {
+  const { payment_id } = updatePaymentSchema.parse(await req.json())
+  const payment = ctx.db.findPaymentById(payment_id)
+  if (!payment) {
+    return ctx.json({
+      ok: false,
+      payment: null,
+      error: "payment_not_found",
+    })
+  }
+
+  ctx.db.updatePaymentStatus(payment_id, "canceled")
+
+  return ctx.json({
+    ok: true,
+    payment: ctx.db.findPaymentById(payment_id)!,
+  })
+})

--- a/routes/payments/cancel.ts
+++ b/routes/payments/cancel.ts
@@ -37,6 +37,14 @@ export default withRouteSpec({
     })
   }
 
+  if (payment.status !== "pending") {
+    return ctx.json({
+      ok: false,
+      payment,
+      error: "invalid_status_transition",
+    })
+  }
+
   ctx.db.updatePaymentStatus(payment_id, "canceled")
 
   return ctx.json({

--- a/routes/payments/complete.ts
+++ b/routes/payments/complete.ts
@@ -1,0 +1,46 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const updatePaymentSchema = z.object({
+  payment_id: z.string().min(1),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: updatePaymentSchema,
+  jsonResponse: z.object({
+    ok: z.boolean(),
+    payment: z
+      .object({
+        payment_id: z.string(),
+        recipient: z.string(),
+        amount: z.number(),
+        currency: z.string(),
+        status: z.enum(["pending", "completed", "canceled", "failed"]),
+        idempotency_key: z.string().optional(),
+        bounty_issue: z.string().optional(),
+        metadata: z.record(z.string(), z.string()),
+        created_at: z.string(),
+        updated_at: z.string(),
+      })
+      .nullable(),
+    error: z.string().optional(),
+  }),
+})(async (req, ctx) => {
+  const { payment_id } = updatePaymentSchema.parse(await req.json())
+  const payment = ctx.db.findPaymentById(payment_id)
+  if (!payment) {
+    return ctx.json({
+      ok: false,
+      payment: null,
+      error: "payment_not_found",
+    })
+  }
+
+  ctx.db.updatePaymentStatus(payment_id, "completed")
+
+  return ctx.json({
+    ok: true,
+    payment: ctx.db.findPaymentById(payment_id)!,
+  })
+})

--- a/routes/payments/complete.ts
+++ b/routes/payments/complete.ts
@@ -37,6 +37,14 @@ export default withRouteSpec({
     })
   }
 
+  if (payment.status !== "pending") {
+    return ctx.json({
+      ok: false,
+      payment,
+      error: "invalid_status_transition",
+    })
+  }
+
   ctx.db.updatePaymentStatus(payment_id, "completed")
 
   return ctx.json({

--- a/routes/payments/get.ts
+++ b/routes/payments/get.ts
@@ -1,0 +1,45 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const getPaymentBodySchema = z.object({
+  payment_id: z.string().min(1),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: getPaymentBodySchema,
+  jsonResponse: z.object({
+    ok: z.boolean(),
+    payment: z
+      .object({
+        payment_id: z.string(),
+        recipient: z.string(),
+        amount: z.number(),
+        currency: z.string(),
+        status: z.enum(["pending", "completed", "canceled", "failed"]),
+        idempotency_key: z.string().optional(),
+        bounty_issue: z.string().optional(),
+        metadata: z.record(z.string(), z.string()),
+        created_at: z.string(),
+        updated_at: z.string(),
+      })
+      .nullable(),
+    error: z.string().optional(),
+  }),
+})(async (req, ctx) => {
+  const { payment_id } = getPaymentBodySchema.parse(await req.json())
+  const payment = ctx.db.findPaymentById(payment_id)
+
+  if (!payment) {
+    return ctx.json({
+      ok: false,
+      payment: null,
+      error: "payment_not_found",
+    })
+  }
+
+  return ctx.json({
+    ok: true,
+    payment,
+  })
+})

--- a/routes/payments/list.ts
+++ b/routes/payments/list.ts
@@ -1,6 +1,13 @@
 import { withRouteSpec } from "lib/middleware/with-winter-spec"
 import { z } from "zod"
 
+const paymentStatusSchema = z.enum([
+  "pending",
+  "completed",
+  "canceled",
+  "failed",
+])
+
 export default withRouteSpec({
   methods: ["GET"],
   jsonResponse: z.object({
@@ -10,7 +17,7 @@ export default withRouteSpec({
         recipient: z.string(),
         amount: z.number(),
         currency: z.string(),
-        status: z.enum(["pending", "completed", "canceled", "failed"]),
+        status: paymentStatusSchema,
         idempotency_key: z.string().optional(),
         bounty_issue: z.string().optional(),
         metadata: z.record(z.string(), z.string()),
@@ -20,7 +27,24 @@ export default withRouteSpec({
     ),
   }),
 })(async (_req, ctx) => {
+  const url = new URL(_req.url)
+  const recipient = url.searchParams.get("recipient")
+  const bountyIssue = url.searchParams.get("bounty_issue")
+  const statusParam = url.searchParams.get("status")
+
+  const parsedStatus = statusParam
+    ? paymentStatusSchema.safeParse(statusParam)
+    : null
+
+  const payments = ctx.db.getState().payments.filter((payment) => {
+    if (recipient && payment.recipient !== recipient) return false
+    if (bountyIssue && payment.bounty_issue !== bountyIssue) return false
+    if (parsedStatus?.success && payment.status !== parsedStatus.data)
+      return false
+    return true
+  })
+
   return ctx.json({
-    payments: ctx.db.getState().payments,
+    payments,
   })
 })

--- a/routes/payments/list.ts
+++ b/routes/payments/list.ts
@@ -36,6 +36,12 @@ export default withRouteSpec({
     ? paymentStatusSchema.safeParse(statusParam)
     : null
 
+  if (statusParam && !parsedStatus?.success) {
+    return ctx.json({
+      payments: [],
+    })
+  }
+
   const payments = ctx.db.getState().payments.filter((payment) => {
     if (recipient && payment.recipient !== recipient) return false
     if (bountyIssue && payment.bounty_issue !== bountyIssue) return false

--- a/routes/payments/list.ts
+++ b/routes/payments/list.ts
@@ -1,0 +1,26 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  jsonResponse: z.object({
+    payments: z.array(
+      z.object({
+        payment_id: z.string(),
+        recipient: z.string(),
+        amount: z.number(),
+        currency: z.string(),
+        status: z.enum(["pending", "completed", "canceled", "failed"]),
+        idempotency_key: z.string().optional(),
+        bounty_issue: z.string().optional(),
+        metadata: z.record(z.string(), z.string()),
+        created_at: z.string(),
+        updated_at: z.string(),
+      }),
+    ),
+  }),
+})(async (_req, ctx) => {
+  return ctx.json({
+    payments: ctx.db.getState().payments,
+  })
+})

--- a/routes/payments/send.ts
+++ b/routes/payments/send.ts
@@ -1,0 +1,55 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const sendPaymentBodySchema = z.object({
+  recipient: z.string().min(1),
+  amount: z.number().positive(),
+  currency: z.string().default("USD"),
+  idempotency_key: z.string().optional(),
+  bounty_issue: z.string().optional(),
+  metadata: z.record(z.string(), z.string()).optional(),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: sendPaymentBodySchema,
+  jsonResponse: z.object({
+    ok: z.boolean(),
+    payment: z.object({
+      payment_id: z.string(),
+      recipient: z.string(),
+      amount: z.number(),
+      currency: z.string(),
+      status: z.enum(["pending", "completed", "canceled", "failed"]),
+      idempotency_key: z.string().optional(),
+      bounty_issue: z.string().optional(),
+      metadata: z.record(z.string(), z.string()),
+      created_at: z.string(),
+      updated_at: z.string(),
+    }),
+    idempotent_replay: z.boolean().optional(),
+  }),
+})(async (req, ctx) => {
+  const body = sendPaymentBodySchema.parse(await req.json())
+
+  if (body.idempotency_key) {
+    const existing = ctx.db.findPaymentByIdempotencyKey(body.idempotency_key)
+    if (existing) {
+      return ctx.json({
+        ok: true,
+        payment: existing,
+        idempotent_replay: true,
+      })
+    }
+  }
+
+  ctx.db.addPayment(body)
+  const payment = body.idempotency_key
+    ? ctx.db.findPaymentByIdempotencyKey(body.idempotency_key)
+    : ctx.db.getState().payments.at(-1)
+
+  return ctx.json({
+    ok: true,
+    payment: payment!,
+  })
+})

--- a/routes/payments/send.ts
+++ b/routes/payments/send.ts
@@ -5,7 +5,7 @@ const sendPaymentBodySchema = z.object({
   recipient: z.string().min(1),
   amount: z.number().positive(),
   currency: z.string().default("USD"),
-  idempotency_key: z.string().optional(),
+  idempotency_key: z.string().trim().min(1).optional(),
   bounty_issue: z.string().optional(),
   metadata: z.record(z.string(), z.string()).optional(),
 })

--- a/routes/payments/send.ts
+++ b/routes/payments/send.ts
@@ -9,6 +9,39 @@ const sendPaymentBodySchema = z.object({
   bounty_issue: z.string().optional(),
   metadata: z.record(z.string(), z.string()).optional(),
 })
+type SendPaymentBody = z.infer<typeof sendPaymentBodySchema>
+
+const hasSameIdempotentPayload = (
+  existingPayment: {
+    recipient: string
+    amount: number
+    currency: string
+    bounty_issue?: string
+    metadata: Record<string, string>
+  },
+  incomingPayment: SendPaymentBody,
+) => {
+  if (existingPayment.recipient !== incomingPayment.recipient) return false
+  if (existingPayment.amount !== incomingPayment.amount) return false
+  if (existingPayment.currency !== incomingPayment.currency) return false
+  if (existingPayment.bounty_issue !== incomingPayment.bounty_issue)
+    return false
+
+  const existingMetadata = existingPayment.metadata
+  const incomingMetadata = incomingPayment.metadata ?? {}
+
+  if (
+    Object.keys(existingMetadata).length !==
+    Object.keys(incomingMetadata).length
+  )
+    return false
+
+  for (const [key, value] of Object.entries(incomingMetadata)) {
+    if (existingMetadata[key] !== value) return false
+  }
+
+  return true
+}
 
 export default withRouteSpec({
   methods: ["POST"],
@@ -28,6 +61,7 @@ export default withRouteSpec({
       updated_at: z.string(),
     }),
     idempotent_replay: z.boolean().optional(),
+    error: z.string().optional(),
   }),
 })(async (req, ctx) => {
   const body = sendPaymentBodySchema.parse(await req.json())
@@ -35,6 +69,14 @@ export default withRouteSpec({
   if (body.idempotency_key) {
     const existing = ctx.db.findPaymentByIdempotencyKey(body.idempotency_key)
     if (existing) {
+      if (!hasSameIdempotentPayload(existing, body)) {
+        return ctx.json({
+          ok: false,
+          payment: existing,
+          error: "idempotency_key_reused_with_different_payload",
+        })
+      }
+
       return ctx.json({
         ok: true,
         payment: existing,

--- a/tests/routes/payments.test.ts
+++ b/tests/routes/payments.test.ts
@@ -30,6 +30,22 @@ test("payment lifecycle routes work and support idempotent send", async () => {
 
   const listRes = await axios.get("/payments/list")
   expect(listRes.data.payments).toHaveLength(1)
+  expect(listRes.data.payments[0].recipient).toBe(sendBody.recipient)
+
+  const listByRecipient = await axios.get("/payments/list", {
+    params: { recipient: sendBody.recipient },
+  })
+  expect(listByRecipient.data.payments).toHaveLength(1)
+
+  const listByBountyIssue = await axios.get("/payments/list", {
+    params: { bounty_issue: "#1" },
+  })
+  expect(listByBountyIssue.data.payments).toHaveLength(1)
+
+  const listNoMatch = await axios.get("/payments/list", {
+    params: { recipient: "someone-else@example.com" },
+  })
+  expect(listNoMatch.data.payments).toHaveLength(0)
 
   const getRes = await axios.post("/payments/get", { payment_id: paymentId })
   expect(getRes.data.ok).toBe(true)
@@ -41,9 +57,15 @@ test("payment lifecycle routes work and support idempotent send", async () => {
   expect(completeRes.data.ok).toBe(true)
   expect(completeRes.data.payment.status).toBe("completed")
 
+  const listCompleted = await axios.get("/payments/list", {
+    params: { status: "completed" },
+  })
+  expect(listCompleted.data.payments).toHaveLength(1)
+
   const cancelRes = await axios.post("/payments/cancel", {
     payment_id: paymentId,
   })
-  expect(cancelRes.data.ok).toBe(true)
-  expect(cancelRes.data.payment.status).toBe("canceled")
+  expect(cancelRes.data.ok).toBe(false)
+  expect(cancelRes.data.error).toBe("invalid_status_transition")
+  expect(cancelRes.data.payment.status).toBe("completed")
 })

--- a/tests/routes/payments.test.ts
+++ b/tests/routes/payments.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("payment lifecycle routes work and support idempotent send", async () => {
+  const { axios } = await getTestServer()
+
+  const sendBody = {
+    recipient: "dev@example.com",
+    amount: 30,
+    currency: "USD",
+    idempotency_key: "issue-1-send-001",
+    bounty_issue: "#1",
+    metadata: {
+      source: "algora",
+    },
+  }
+
+  const firstSend = await axios.post("/payments/send", sendBody)
+  expect(firstSend.data.ok).toBe(true)
+  expect(firstSend.data.payment.status).toBe("pending")
+
+  const replaySend = await axios.post("/payments/send", sendBody)
+  expect(replaySend.data.ok).toBe(true)
+  expect(replaySend.data.idempotent_replay).toBe(true)
+  expect(replaySend.data.payment.payment_id).toBe(
+    firstSend.data.payment.payment_id,
+  )
+
+  const paymentId = firstSend.data.payment.payment_id
+
+  const listRes = await axios.get("/payments/list")
+  expect(listRes.data.payments).toHaveLength(1)
+
+  const getRes = await axios.post("/payments/get", { payment_id: paymentId })
+  expect(getRes.data.ok).toBe(true)
+  expect(getRes.data.payment.payment_id).toBe(paymentId)
+
+  const completeRes = await axios.post("/payments/complete", {
+    payment_id: paymentId,
+  })
+  expect(completeRes.data.ok).toBe(true)
+  expect(completeRes.data.payment.status).toBe("completed")
+
+  const cancelRes = await axios.post("/payments/cancel", {
+    payment_id: paymentId,
+  })
+  expect(cancelRes.data.ok).toBe(true)
+  expect(cancelRes.data.payment.status).toBe("canceled")
+})

--- a/tests/routes/payments.test.ts
+++ b/tests/routes/payments.test.ts
@@ -69,3 +69,29 @@ test("payment lifecycle routes work and support idempotent send", async () => {
   expect(cancelRes.data.error).toBe("invalid_status_transition")
   expect(cancelRes.data.payment.status).toBe("completed")
 })
+
+test("send rejects blank idempotency key", async () => {
+  const { axios } = await getTestServer()
+
+  let error: unknown = null
+  try {
+    await axios.post("/payments/send", {
+      recipient: "dev@example.com",
+      amount: 30,
+      currency: "USD",
+      idempotency_key: "   ",
+    })
+  } catch (caught) {
+    error = caught
+  }
+
+  expect(error).not.toBeNull()
+  const maybeError = error as {
+    status?: number
+    response?: { status?: number }
+  }
+  expect(maybeError.status ?? maybeError.response?.status).toBe(400)
+
+  const listRes = await axios.get("/payments/list")
+  expect(listRes.data.payments).toHaveLength(0)
+})

--- a/tests/routes/payments.test.ts
+++ b/tests/routes/payments.test.ts
@@ -26,6 +26,18 @@ test("payment lifecycle routes work and support idempotent send", async () => {
     firstSend.data.payment.payment_id,
   )
 
+  const conflictingReplay = await axios.post("/payments/send", {
+    ...sendBody,
+    amount: 31,
+  })
+  expect(conflictingReplay.data.ok).toBe(false)
+  expect(conflictingReplay.data.error).toBe(
+    "idempotency_key_reused_with_different_payload",
+  )
+  expect(conflictingReplay.data.payment.payment_id).toBe(
+    firstSend.data.payment.payment_id,
+  )
+
   const paymentId = firstSend.data.payment.payment_id
 
   const listRes = await axios.get("/payments/list")
@@ -61,6 +73,11 @@ test("payment lifecycle routes work and support idempotent send", async () => {
     params: { status: "completed" },
   })
   expect(listCompleted.data.payments).toHaveLength(1)
+
+  const listInvalidStatus = await axios.get("/payments/list", {
+    params: { status: "complete" },
+  })
+  expect(listInvalidStatus.data.payments).toHaveLength(0)
 
   const cancelRes = await axios.post("/payments/cancel", {
     payment_id: paymentId,


### PR DESCRIPTION
## Summary
- add fake payment routes: `send`, `list`, `get`, `complete`, and `cancel`
- add payment schema + database helpers for lifecycle/state transitions
- support idempotency keys in `POST /payments/send` to make retries safe
- add end-to-end route test covering lifecycle and idempotent replay behavior
- document the new payment routes in README

## Validation
- Could not run tests in this environment because `bun` is not installed.

/claim #1