### PR TITLE
feat: add GET /things/get and POST /things/delete endpoints

### DIFF
--- a/lib/db/db-client.ts
+++ b/lib/db/db-client.ts
@@ -21,4 +21,9 @@ const initializer = combine(databaseSchema.parse({}), (set) => ({
       idCounter: state.idCounter + 1,
     }))
   },
+  removeThing: (thing_id: string) => {
+    set((state) => ({
+      things: state.things.filter((t) => t.thing_id !== thing_id),
+    }))
+  },
 }))

--- a/routes/things/delete.ts
+++ b/routes/things/delete.ts
@@ -1,0 +1,16 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: z.object({
+    thing_id: z.string(),
+  }),
+  jsonResponse: z.object({
+    ok: z.boolean(),
+  }),
+})(async (req, ctx) => {
+  const { thing_id } = await req.json()
+  ctx.db.removeThing(thing_id)
+  return ctx.json({ ok: true })
+})

--- a/routes/things/get.ts
+++ b/routes/things/get.ts
@@ -1,0 +1,25 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  queryParams: z.object({
+    thing_id: z.string(),
+  }),
+  jsonResponse: z.object({
+    thing: z.object({
+      thing_id: z.string(),
+      name: z.string(),
+      description: z.string(),
+    }),
+  }),
+})((req, ctx) => {
+  const { thing_id } = req.query
+  const thing = ctx.db.things.find((t) => t.thing_id === thing_id)
+
+  if (!thing) {
+    return ctx.json({ error: "Thing not found" }, { status: 404 })
+  }
+
+  return ctx.json({ thing })
+})

--- a/tests/routes/things/delete.test.ts
+++ b/tests/routes/things/delete.test.ts
@@ -1,0 +1,32 @@
+import { getTestServer } from "tests/fixtures/get-test-server"
+import { test, expect } from "bun:test"
+
+test("delete a thing", async () => {
+  const { axios } = await getTestServer()
+
+  await axios.post("/things/create", {
+    name: "Thing1",
+    description: "Thing1 Description",
+  })
+
+  const { data: listBefore } = await axios.get("/things/list")
+  expect(listBefore.things).toHaveLength(1)
+
+  await axios.post("/things/delete", {
+    thing_id: "0",
+  })
+
+  const { data: listAfter } = await axios.get("/things/list")
+  expect(listAfter.things).toHaveLength(0)
+})
+
+test("delete a non-existent thing does not error", async () => {
+  const { axios } = await getTestServer()
+
+  const res = await axios.post("/things/delete", {
+    thing_id: "999",
+  })
+
+  expect(res.status).toBe(200)
+  expect(res.data.ok).toBe(true)
+})

--- a/tests/routes/things/get.test.ts
+++ b/tests/routes/things/get.test.ts
@@ -1,0 +1,29 @@
+import { getTestServer } from "tests/fixtures/get-test-server"
+import { test, expect } from "bun:test"
+
+test("get a thing by id", async () => {
+  const { axios } = await getTestServer()
+
+  await axios.post("/things/create", {
+    name: "Thing1",
+    description: "Thing1 Description",
+  })
+
+  const { data } = await axios.get("/things/get?thing_id=0")
+
+  expect(data.thing).toEqual({
+    thing_id: "0",
+    name: "Thing1",
+    description: "Thing1 Description",
+  })
+})
+
+test("get a thing that doesn't exist returns 404", async () => {
+  const { axios } = await getTestServer()
+
+  try {
+    await axios.get("/things/get?thing_id=999")
+  } catch (e: any) {
+    expect(e.status).toBe(404)
+  }
+})


### PR DESCRIPTION
## Summary\n\nAdds two missing CRUD endpoints for the things resource:\n\n### New Endpoints\n\n- **GET /things/get?thing_id=ID** — Retrieve a single thing by its ID. Returns 404 if not found.\n- **POST /things/delete** — Delete a thing by thing_id.\n\n### Changes\n\n- `routes/things/get.ts` — New endpoint with query param validation via zod\n- `routes/things/delete.ts` — New endpoint with JSON body validation via zod\n- `lib/db/db-client.ts` — Added `removeThing(thing_id)` method to the database store\n- `tests/routes/things/get.test.ts` — Tests for get endpoint (success + 404 case)\n- `tests/routes/things/delete.test.ts` — Tests for delete endpoint (success + non-existent thing)\n\nCloses #1