### PR TITLE
Add fake payment send and list API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,8 @@ This is a template project with best-practice modules:
 - Winterspec for defining the API
 - bun testing
 - Zustand store with zod definition for database state
+
+## Payments
+
+- `POST /payments/send` creates a fake payment with recipient, amount, currency, and optional bounty issue.
+- `GET /payments/list` returns the fake payments stored in memory.

--- a/lib/db/db-client.ts
+++ b/lib/db/db-client.ts
@@ -2,7 +2,12 @@ import { createStore, type StoreApi } from "zustand/vanilla"
 import { immer } from "zustand/middleware/immer"
 import { hoist, type HoistedStoreApi } from "zustand-hoist"
 
-import { databaseSchema, type DatabaseSchema, type Thing } from "./schema.ts"
+import {
+  databaseSchema,
+  type DatabaseSchema,
+  type Payment,
+  type Thing,
+} from "./schema.ts"
 import { combine } from "zustand/middleware"
 
 export const createDatabase = () => {
@@ -20,5 +25,19 @@ const initializer = combine(databaseSchema.parse({}), (set) => ({
       ],
       idCounter: state.idCounter + 1,
     }))
+  },
+  sendPayment: (payment: Omit<Payment, "payment_id" | "status">) => {
+    let payment_id = ""
+    set((state) => {
+      payment_id = `payment_${state.idCounter}`
+      return {
+        payments: [
+          ...state.payments,
+          { ...payment, payment_id, status: "sent" as const },
+        ],
+        idCounter: state.idCounter + 1,
+      }
+    })
+    return payment_id
   },
 }))

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -9,8 +9,19 @@ export const thingSchema = z.object({
 })
 export type Thing = z.infer<typeof thingSchema>
 
+export const paymentSchema = z.object({
+  payment_id: z.string(),
+  recipient: z.string(),
+  amount: z.number(),
+  currency: z.string(),
+  bounty_issue: z.number().optional(),
+  status: z.enum(["pending", "sent"]),
+})
+export type Payment = z.infer<typeof paymentSchema>
+
 export const databaseSchema = z.object({
   idCounter: z.number().default(0),
   things: z.array(thingSchema).default([]),
+  payments: z.array(paymentSchema).default([]),
 })
 export type DatabaseSchema = z.infer<typeof databaseSchema>

--- a/routes/payments/list.ts
+++ b/routes/payments/list.ts
@@ -1,0 +1,20 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  jsonResponse: z.object({
+    payments: z.array(
+      z.object({
+        payment_id: z.string(),
+        recipient: z.string(),
+        amount: z.number(),
+        currency: z.string(),
+        bounty_issue: z.number().optional(),
+        status: z.enum(["pending", "sent"]),
+      }),
+    ),
+  }),
+})((req, ctx) => {
+  return ctx.json({ payments: ctx.db.payments })
+})

--- a/routes/payments/send.ts
+++ b/routes/payments/send.ts
@@ -1,0 +1,27 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const paymentResponse = z.object({
+  payment_id: z.string(),
+  recipient: z.string(),
+  amount: z.number(),
+  currency: z.string(),
+  bounty_issue: z.number().optional(),
+  status: z.enum(["pending", "sent"]),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: z.object({
+    recipient: z.string(),
+    amount: z.number().positive(),
+    currency: z.string().default("USD"),
+    bounty_issue: z.number().optional(),
+  }),
+  jsonResponse: paymentResponse,
+})(async (req, ctx) => {
+  const body = await req.json()
+  const payment_id = ctx.db.sendPayment(body)
+  const payment = ctx.db.payments.find((p) => p.payment_id === payment_id)!
+  return ctx.json(payment)
+})

--- a/tests/routes/payments/send.test.ts
+++ b/tests/routes/payments/send.test.ts
@@ -1,0 +1,26 @@
+import { getTestServer } from "tests/fixtures/get-test-server"
+import { test, expect } from "bun:test"
+
+test("send and list payments", async () => {
+  const { axios } = await getTestServer()
+
+  const { data: payment } = await axios.post("/payments/send", {
+    recipient: "maintainer@example.com",
+    amount: 10,
+    currency: "USD",
+    bounty_issue: 1,
+  })
+
+  expect(payment).toMatchObject({
+    payment_id: "payment_0",
+    recipient: "maintainer@example.com",
+    amount: 10,
+    currency: "USD",
+    bounty_issue: 1,
+    status: "sent",
+  })
+
+  const { data } = await axios.get("/payments/list")
+  expect(data.payments).toHaveLength(1)
+  expect(data.payments[0]).toEqual(payment)
+})


### PR DESCRIPTION
/claim #1

Adds a small fake payment API on top of the starter project.

What changed:
- `POST /payments/send` creates a sent fake payment with recipient, amount, currency, and optional bounty issue.
- `GET /payments/list` returns the in-memory payment records.
- Adds a route test for sending and listing a payment.
- Adds short README notes for the new endpoints.

Verification:
- `npx --yes bun test tests/routes/payments/send.test.ts`
- `npx --yes bun test`
- `npx --yes bun x winterspec bundle -o dist/bundle.js`
- `npx --yes biome check lib\db\schema.ts lib\db\db-client.ts routes\payments\send.ts routes\payments\list.ts tests\routes\payments\send.test.ts README.md`