### PR TITLE
Add fake payments API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The fake payment routes are intentionally in-memory and safe for local testing:
 - `GET /payments/get?payment_id=...` returns one payment.
 - `POST /payments/complete` marks a pending payment as completed.
 - `POST /payments/cancel` marks a pending payment as canceled.
+- `POST /payments/fail` marks a pending payment as failed.
 
 `POST /payments/send` also supports an optional `idempotency_key` so retrying the
 same fake payment request does not create duplicate records.

--- a/README.md
+++ b/README.md
@@ -4,3 +4,16 @@ This is a template project with best-practice modules:
 - Winterspec for defining the API
 - bun testing
 - Zustand store with zod definition for database state
+
+## Fake payment API
+
+The fake payment routes are intentionally in-memory and safe for local testing:
+
+- `POST /payments/send` creates a pending fake payment and accepts optional bounty metadata.
+- `GET /payments/list` lists payments, with optional `recipient`, `repository`, and `status` filters.
+- `GET /payments/get?payment_id=...` returns one payment.
+- `POST /payments/complete` marks a pending payment as completed.
+- `POST /payments/cancel` marks a pending payment as canceled.
+
+`POST /payments/send` also supports an optional `idempotency_key` so retrying the
+same fake payment request does not create duplicate records.

--- a/lib/db/db-client.ts
+++ b/lib/db/db-client.ts
@@ -1,9 +1,15 @@
-import { createStore, type StoreApi } from "zustand/vanilla"
+import { type HoistedStoreApi, hoist } from "zustand-hoist"
 import { immer } from "zustand/middleware/immer"
-import { hoist, type HoistedStoreApi } from "zustand-hoist"
+import { type StoreApi, createStore } from "zustand/vanilla"
 
-import { databaseSchema, type DatabaseSchema, type Thing } from "./schema.ts"
 import { combine } from "zustand/middleware"
+import {
+  type DatabaseSchema,
+  type Payment,
+  type PaymentStatus,
+  type Thing,
+  databaseSchema,
+} from "./schema.ts"
 
 export const createDatabase = () => {
   return hoist(createStore(initializer))
@@ -11,7 +17,23 @@ export const createDatabase = () => {
 
 export type DbClient = ReturnType<typeof createDatabase>
 
-const initializer = combine(databaseSchema.parse({}), (set) => ({
+type SendPaymentInput = Pick<Payment, "recipient" | "amount"> &
+  Partial<
+    Pick<
+      Payment,
+      | "currency"
+      | "bounty_id"
+      | "issue_number"
+      | "repository"
+      | "idempotency_key"
+    >
+  >
+
+type ListPaymentsFilters = Partial<
+  Pick<Payment, "recipient" | "status" | "repository">
+>
+
+const initializer = combine(databaseSchema.parse({}), (set, get) => ({
   addThing: (thing: Omit<Thing, "thing_id">) => {
     set((state) => ({
       things: [
@@ -20,5 +42,83 @@ const initializer = combine(databaseSchema.parse({}), (set) => ({
       ],
       idCounter: state.idCounter + 1,
     }))
+  },
+  sendPayment: (input: SendPaymentInput) => {
+    const idempotentPayment =
+      input.idempotency_key != null
+        ? get().payments.find(
+            (payment) => payment.idempotency_key === input.idempotency_key,
+          )
+        : undefined
+
+    if (idempotentPayment) {
+      return idempotentPayment
+    }
+
+    const now = new Date().toISOString()
+    const payment: Payment = {
+      payment_id: get().paymentIdCounter.toString(),
+      recipient: input.recipient,
+      amount: input.amount,
+      currency: input.currency ?? "USD",
+      status: "pending",
+      bounty_id: input.bounty_id,
+      issue_number: input.issue_number,
+      repository: input.repository,
+      idempotency_key: input.idempotency_key,
+      created_at: now,
+      updated_at: now,
+    }
+
+    set((state) => ({
+      payments: [...state.payments, payment],
+      paymentIdCounter: state.paymentIdCounter + 1,
+    }))
+
+    return payment
+  },
+  getPayment: (paymentId: string) => {
+    return get().payments.find((payment) => payment.payment_id === paymentId)
+  },
+  listPayments: (filters: ListPaymentsFilters = {}) => {
+    return get().payments.filter((payment) => {
+      if (filters.recipient && payment.recipient !== filters.recipient) {
+        return false
+      }
+      if (filters.status && payment.status !== filters.status) {
+        return false
+      }
+      if (filters.repository && payment.repository !== filters.repository) {
+        return false
+      }
+      return true
+    })
+  },
+  updatePaymentStatus: (paymentId: string, status: PaymentStatus) => {
+    const payment = get().payments.find(
+      (candidate) => candidate.payment_id === paymentId,
+    )
+
+    if (!payment) {
+      return undefined
+    }
+
+    if (payment.status !== "pending") {
+      return payment
+    }
+
+    const updatedPayment = {
+      ...payment,
+      status,
+      updated_at: new Date().toISOString(),
+    }
+
+    set((state) => ({
+      payments: state.payments.map((candidate) =>
+        candidate.payment_id === paymentId ? updatedPayment : candidate,
+      ),
+    }))
+
+    return updatedPayment
   },
 }))

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -9,7 +9,12 @@ export const thingSchema = z.object({
 })
 export type Thing = z.infer<typeof thingSchema>
 
-export const paymentStatusSchema = z.enum(["pending", "completed", "canceled"])
+export const paymentStatusSchema = z.enum([
+  "pending",
+  "completed",
+  "canceled",
+  "failed",
+])
 export type PaymentStatus = z.infer<typeof paymentStatusSchema>
 
 export const paymentSchema = z.object({

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -9,8 +9,28 @@ export const thingSchema = z.object({
 })
 export type Thing = z.infer<typeof thingSchema>
 
+export const paymentStatusSchema = z.enum(["pending", "completed", "canceled"])
+export type PaymentStatus = z.infer<typeof paymentStatusSchema>
+
+export const paymentSchema = z.object({
+  payment_id: z.string(),
+  recipient: z.string(),
+  amount: z.number().positive(),
+  currency: z.string(),
+  status: paymentStatusSchema,
+  bounty_id: z.string().optional(),
+  issue_number: z.number().int().positive().optional(),
+  repository: z.string().optional(),
+  idempotency_key: z.string().optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+export type Payment = z.infer<typeof paymentSchema>
+
 export const databaseSchema = z.object({
   idCounter: z.number().default(0),
   things: z.array(thingSchema).default([]),
+  paymentIdCounter: z.number().default(0),
+  payments: z.array(paymentSchema).default([]),
 })
 export type DatabaseSchema = z.infer<typeof databaseSchema>

--- a/lib/middleware/with-db.ts
+++ b/lib/middleware/with-db.ts
@@ -2,6 +2,8 @@ import type { DbClient } from "lib/db/db-client"
 import { createDatabase } from "lib/db/db-client"
 import type { Middleware } from "winterspec"
 
+const fallbackDb = createDatabase()
+
 export const withDb: Middleware<
   {},
   {
@@ -9,7 +11,7 @@ export const withDb: Middleware<
   }
 > = async (req, ctx, next) => {
   if (!ctx.db) {
-    ctx.db = createDatabase()
+    ctx.db = fallbackDb
   }
   return next(req, ctx)
 }

--- a/lib/payments/response-schemas.ts
+++ b/lib/payments/response-schemas.ts
@@ -1,0 +1,14 @@
+import { paymentSchema } from "lib/db/schema"
+import { z } from "zod"
+
+export const paymentResponseSchema = z.object({
+  payment: paymentSchema,
+})
+
+export const paymentsResponseSchema = z.object({
+  payments: z.array(paymentSchema),
+})
+
+export const paymentErrorResponseSchema = z.object({
+  error: z.string(),
+})

--- a/routes/payments/cancel.ts
+++ b/routes/payments/cancel.ts
@@ -1,0 +1,25 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import {
+  paymentErrorResponseSchema,
+  paymentResponseSchema,
+} from "lib/payments/response-schemas"
+import { z } from "zod"
+
+const paymentStatusRequestSchema = z.object({
+  payment_id: z.string().min(1),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: paymentStatusRequestSchema,
+  jsonResponse: paymentResponseSchema.or(paymentErrorResponseSchema),
+})(async (req, ctx) => {
+  const { payment_id } = paymentStatusRequestSchema.parse(await req.json())
+  const payment = ctx.db.updatePaymentStatus(payment_id, "canceled")
+
+  if (!payment) {
+    return ctx.json({ error: "Payment not found" }, { status: 404 })
+  }
+
+  return ctx.json({ payment })
+})

--- a/routes/payments/complete.ts
+++ b/routes/payments/complete.ts
@@ -1,0 +1,25 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import {
+  paymentErrorResponseSchema,
+  paymentResponseSchema,
+} from "lib/payments/response-schemas"
+import { z } from "zod"
+
+const paymentStatusRequestSchema = z.object({
+  payment_id: z.string().min(1),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: paymentStatusRequestSchema,
+  jsonResponse: paymentResponseSchema.or(paymentErrorResponseSchema),
+})(async (req, ctx) => {
+  const { payment_id } = paymentStatusRequestSchema.parse(await req.json())
+  const payment = ctx.db.updatePaymentStatus(payment_id, "completed")
+
+  if (!payment) {
+    return ctx.json({ error: "Payment not found" }, { status: 404 })
+  }
+
+  return ctx.json({ payment })
+})

--- a/routes/payments/fail.ts
+++ b/routes/payments/fail.ts
@@ -1,0 +1,25 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import {
+  paymentErrorResponseSchema,
+  paymentResponseSchema,
+} from "lib/payments/response-schemas"
+import { z } from "zod"
+
+const paymentStatusRequestSchema = z.object({
+  payment_id: z.string().min(1),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: paymentStatusRequestSchema,
+  jsonResponse: paymentResponseSchema.or(paymentErrorResponseSchema),
+})(async (req, ctx) => {
+  const { payment_id } = paymentStatusRequestSchema.parse(await req.json())
+  const payment = ctx.db.updatePaymentStatus(payment_id, "failed")
+
+  if (!payment) {
+    return ctx.json({ error: "Payment not found" }, { status: 404 })
+  }
+
+  return ctx.json({ payment })
+})

--- a/routes/payments/get.ts
+++ b/routes/payments/get.ts
@@ -1,0 +1,25 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import {
+  paymentErrorResponseSchema,
+  paymentResponseSchema,
+} from "lib/payments/response-schemas"
+import { z } from "zod"
+
+const getPaymentQuerySchema = z.object({
+  payment_id: z.string().min(1),
+})
+
+export default withRouteSpec({
+  methods: ["GET"],
+  jsonResponse: paymentResponseSchema.or(paymentErrorResponseSchema),
+})(async (req, ctx) => {
+  const query = Object.fromEntries(new URL(req.url).searchParams.entries())
+  const { payment_id } = getPaymentQuerySchema.parse(query)
+  const payment = ctx.db.getPayment(payment_id)
+
+  if (!payment) {
+    return ctx.json({ error: "Payment not found" }, { status: 404 })
+  }
+
+  return ctx.json({ payment })
+})

--- a/routes/payments/list.ts
+++ b/routes/payments/list.ts
@@ -1,0 +1,22 @@
+import { paymentStatusSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { paymentsResponseSchema } from "lib/payments/response-schemas"
+import { z } from "zod"
+
+const listPaymentQuerySchema = z.object({
+  recipient: z.string().optional(),
+  repository: z.string().optional(),
+  status: paymentStatusSchema.optional(),
+})
+
+export default withRouteSpec({
+  methods: ["GET"],
+  jsonResponse: paymentsResponseSchema,
+})(async (req, ctx) => {
+  const query = Object.fromEntries(new URL(req.url).searchParams.entries())
+  const filters = listPaymentQuerySchema.parse(query)
+
+  return ctx.json({
+    payments: ctx.db.listPayments(filters),
+  })
+})

--- a/routes/payments/send.ts
+++ b/routes/payments/send.ts
@@ -1,0 +1,24 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { paymentResponseSchema } from "lib/payments/response-schemas"
+import { z } from "zod"
+
+const sendPaymentRequestSchema = z.object({
+  recipient: z.string().min(1),
+  amount: z.number().positive(),
+  currency: z.string().min(3).default("USD"),
+  bounty_id: z.string().optional(),
+  issue_number: z.number().int().positive().optional(),
+  repository: z.string().optional(),
+  idempotency_key: z.string().optional(),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: sendPaymentRequestSchema,
+  jsonResponse: paymentResponseSchema,
+})(async (req, ctx) => {
+  const paymentInput = sendPaymentRequestSchema.parse(await req.json())
+  const payment = ctx.db.sendPayment(paymentInput)
+
+  return ctx.json({ payment })
+})

--- a/tests/middleware/with-db.test.ts
+++ b/tests/middleware/with-db.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test"
+import { createDatabase } from "lib/db/db-client"
+import { withDb } from "lib/middleware/with-db"
+
+const request = new Request("http://localhost/test") as any
+const next = async () => new Response("ok")
+
+test("reuses fallback db when middleware context has no db", async () => {
+  const firstContext: Record<string, unknown> = {}
+  const secondContext: Record<string, unknown> = {}
+
+  await withDb(request, firstContext as any, next as any)
+  await withDb(request, secondContext as any, next as any)
+
+  expect(firstContext.db).toBe(secondContext.db)
+})
+
+test("preserves db supplied by an outer middleware", async () => {
+  const suppliedDb = createDatabase()
+  const context = { db: suppliedDb }
+
+  await withDb(request, context as any, next as any)
+
+  expect(context.db).toBe(suppliedDb)
+})

--- a/tests/routes/payments.test.ts
+++ b/tests/routes/payments.test.ts
@@ -1,0 +1,103 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("send and list fake payments", async () => {
+  const { axios } = await getTestServer()
+
+  const { data: sendData } = await axios.post("/payments/send", {
+    recipient: "alice",
+    amount: 10,
+    currency: "USD",
+    bounty_id: "1",
+    issue_number: 1,
+    repository: "tscircuit/fake-algora",
+  })
+
+  expect(sendData.payment).toMatchObject({
+    payment_id: "0",
+    recipient: "alice",
+    amount: 10,
+    currency: "USD",
+    status: "pending",
+    bounty_id: "1",
+    issue_number: 1,
+    repository: "tscircuit/fake-algora",
+  })
+
+  const { data: listData } = await axios.get("/payments/list", {
+    params: {
+      recipient: "alice",
+      status: "pending",
+    },
+  })
+
+  expect(listData.payments).toHaveLength(1)
+  expect(listData.payments[0].payment_id).toBe("0")
+})
+
+test("reuses payments for matching idempotency keys", async () => {
+  const { axios } = await getTestServer()
+
+  const { data: firstSendData } = await axios.post("/payments/send", {
+    recipient: "bob",
+    amount: 15,
+    idempotency_key: "retry-token",
+  })
+
+  const { data: secondSendData } = await axios.post("/payments/send", {
+    recipient: "bob",
+    amount: 15,
+    idempotency_key: "retry-token",
+  })
+
+  expect(secondSendData.payment.payment_id).toBe(
+    firstSendData.payment.payment_id,
+  )
+
+  const { data: listData } = await axios.get("/payments/list")
+  expect(listData.payments).toHaveLength(1)
+})
+
+test("gets and completes pending fake payments", async () => {
+  const { axios } = await getTestServer()
+
+  const { data: sendData } = await axios.post("/payments/send", {
+    recipient: "carol",
+    amount: 25,
+  })
+
+  const { data: getData } = await axios.get("/payments/get", {
+    params: {
+      payment_id: sendData.payment.payment_id,
+    },
+  })
+
+  expect(getData.payment.status).toBe("pending")
+
+  const { data: completeData } = await axios.post("/payments/complete", {
+    payment_id: sendData.payment.payment_id,
+  })
+
+  expect(completeData.payment.status).toBe("completed")
+})
+
+test("does not mutate terminal fake payment states", async () => {
+  const { axios } = await getTestServer()
+
+  const { data: sendData } = await axios.post("/payments/send", {
+    recipient: "dana",
+    amount: 30,
+  })
+
+  const { data: cancelData } = await axios.post("/payments/cancel", {
+    payment_id: sendData.payment.payment_id,
+  })
+
+  expect(cancelData.payment.status).toBe("canceled")
+
+  const { data: completeData } = await axios.post("/payments/complete", {
+    payment_id: sendData.payment.payment_id,
+  })
+
+  expect(completeData.payment.status).toBe("canceled")
+})

--- a/tests/routes/payments.test.ts
+++ b/tests/routes/payments.test.ts
@@ -101,3 +101,29 @@ test("does not mutate terminal fake payment states", async () => {
 
   expect(completeData.payment.status).toBe("canceled")
 })
+
+test("marks pending fake payments as failed", async () => {
+  const { axios } = await getTestServer()
+
+  const { data: sendData } = await axios.post("/payments/send", {
+    recipient: "erin",
+    amount: 45,
+    repository: "tscircuit/fake-algora",
+  })
+
+  const { data: failData } = await axios.post("/payments/fail", {
+    payment_id: sendData.payment.payment_id,
+  })
+
+  expect(failData.payment.status).toBe("failed")
+
+  const { data: listData } = await axios.get("/payments/list", {
+    params: {
+      repository: "tscircuit/fake-algora",
+      status: "failed",
+    },
+  })
+
+  expect(listData.payments).toHaveLength(1)
+  expect(listData.payments[0].payment_id).toBe(sendData.payment.payment_id)
+})


### PR DESCRIPTION
/claim #1

## Summary
- adds an in-memory fake payment model with pending, completed, canceled, and failed lifecycle states
- adds Winterspec routes for send, list, get, complete, cancel, and fail
- supports idempotency keys on `/payments/send` so retried fake payment requests do not create duplicates
- keeps terminal payments immutable, so completed/canceled/failed fake payments are not mutated by later lifecycle calls
- documents the fake payment endpoints in the README

## Verification
- `bun test tests/routes/payments.test.ts`
- `bun test`
- `bunx biome check lib/db/schema.ts lib/db/db-client.ts lib/payments/response-schemas.ts routes/payments tests/routes/payments.test.ts README.md`
- `bun run build`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`

## Follow-up check, 2026-05-23
- Re-ran `bun test tests/routes/payments.test.ts`: 5 passed, covering send/list, idempotency replay, get/complete, terminal-state protection, and failed-payment filtering.

## Notes
This is intentionally a fake in-memory API only. It does not process real payments, call external payment services, or include any payout/private data.
