### PR TITLE
Add fake payments API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,20 @@ This is a template project with best-practice modules:
 - Winterspec for defining the API
 - bun testing
 - Zustand store with zod definition for database state
+
+## Fake payments API
+
+The app includes a small in-memory fake payment lifecycle for bounty-style
+payment testing:
+
+- `POST /payments/send` creates a pending payment. Body fields:
+  `recipient`, `amount`, optional `currency`, `repository`, `issue_number`,
+  `bounty_id`, and `idempotency_key`.
+- `GET /payments/list` returns payments, with optional `recipient`,
+  `repository`, `issue_number`, and `status` query filters.
+- `GET /payments/get?payment_id=pay_0` returns one payment.
+- `POST /payments/complete` marks a pending payment as completed.
+- `POST /payments/cancel` marks a pending payment as canceled.
+
+If `idempotency_key` is supplied to `/payments/send`, retries return the
+original payment instead of creating a duplicate.

--- a/lib/db/db-client.ts
+++ b/lib/db/db-client.ts
@@ -36,6 +36,21 @@ type PaymentFilters = {
 
 const now = () => new Date().toISOString()
 
+const hasMatchingIdempotencyScope = (
+  payment: Payment,
+  paymentInput: CreatePaymentInput,
+) => {
+  return (
+    payment.idempotency_key === paymentInput.idempotency_key &&
+    payment.recipient === paymentInput.recipient &&
+    payment.amount === paymentInput.amount &&
+    payment.currency === paymentInput.currency &&
+    payment.repository === paymentInput.repository &&
+    payment.issue_number === paymentInput.issue_number &&
+    payment.bounty_id === paymentInput.bounty_id
+  )
+}
+
 const initializer = combine(databaseSchema.parse({}), (set, get) => ({
   addThing: (thing: Omit<Thing, "thing_id">) => {
     set((state) => ({
@@ -50,8 +65,8 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
     paymentInput: CreatePaymentInput,
   ): { payment: Payment; replayed: boolean } => {
     if (paymentInput.idempotency_key) {
-      const replayedPayment = get().payments.find(
-        (payment) => payment.idempotency_key === paymentInput.idempotency_key,
+      const replayedPayment = get().payments.find((payment) =>
+        hasMatchingIdempotencyScope(payment, paymentInput),
       )
       if (replayedPayment) {
         return { payment: replayedPayment, replayed: true }
@@ -76,10 +91,16 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
   },
   listPayments: (filters: PaymentFilters = {}) => {
     return get().payments.filter((payment) => {
-      if (filters.recipient && payment.recipient !== filters.recipient) {
+      if (
+        filters.recipient !== undefined &&
+        payment.recipient !== filters.recipient
+      ) {
         return false
       }
-      if (filters.repository && payment.repository !== filters.repository) {
+      if (
+        filters.repository !== undefined &&
+        payment.repository !== filters.repository
+      ) {
         return false
       }
       if (
@@ -88,7 +109,7 @@ const initializer = combine(databaseSchema.parse({}), (set, get) => ({
       ) {
         return false
       }
-      if (filters.status && payment.status !== filters.status) {
+      if (filters.status !== undefined && payment.status !== filters.status) {
         return false
       }
       return true

--- a/lib/db/db-client.ts
+++ b/lib/db/db-client.ts
@@ -1,9 +1,14 @@
-import { createStore, type StoreApi } from "zustand/vanilla"
-import { immer } from "zustand/middleware/immer"
-import { hoist, type HoistedStoreApi } from "zustand-hoist"
+import { hoist } from "zustand-hoist"
+import { createStore } from "zustand/vanilla"
 
-import { databaseSchema, type DatabaseSchema, type Thing } from "./schema.ts"
 import { combine } from "zustand/middleware"
+
+import {
+  type Payment,
+  type PaymentStatus,
+  type Thing,
+  databaseSchema,
+} from "./schema.ts"
 
 export const createDatabase = () => {
   return hoist(createStore(initializer))
@@ -11,7 +16,27 @@ export const createDatabase = () => {
 
 export type DbClient = ReturnType<typeof createDatabase>
 
-const initializer = combine(databaseSchema.parse({}), (set) => ({
+type CreatePaymentInput = Pick<
+  Payment,
+  | "recipient"
+  | "amount"
+  | "currency"
+  | "repository"
+  | "issue_number"
+  | "bounty_id"
+  | "idempotency_key"
+>
+
+type PaymentFilters = {
+  recipient?: string
+  repository?: string
+  issue_number?: number
+  status?: PaymentStatus
+}
+
+const now = () => new Date().toISOString()
+
+const initializer = combine(databaseSchema.parse({}), (set, get) => ({
   addThing: (thing: Omit<Thing, "thing_id">) => {
     set((state) => ({
       things: [
@@ -20,5 +45,88 @@ const initializer = combine(databaseSchema.parse({}), (set) => ({
       ],
       idCounter: state.idCounter + 1,
     }))
+  },
+  sendPayment: (
+    paymentInput: CreatePaymentInput,
+  ): { payment: Payment; replayed: boolean } => {
+    if (paymentInput.idempotency_key) {
+      const replayedPayment = get().payments.find(
+        (payment) => payment.idempotency_key === paymentInput.idempotency_key,
+      )
+      if (replayedPayment) {
+        return { payment: replayedPayment, replayed: true }
+      }
+    }
+
+    const timestamp = now()
+    const payment: Payment = {
+      ...paymentInput,
+      payment_id: `pay_${get().idCounter}`,
+      status: "pending",
+      created_at: timestamp,
+      updated_at: timestamp,
+    }
+
+    set((state) => ({
+      payments: [...state.payments, payment],
+      idCounter: state.idCounter + 1,
+    }))
+
+    return { payment, replayed: false }
+  },
+  listPayments: (filters: PaymentFilters = {}) => {
+    return get().payments.filter((payment) => {
+      if (filters.recipient && payment.recipient !== filters.recipient) {
+        return false
+      }
+      if (filters.repository && payment.repository !== filters.repository) {
+        return false
+      }
+      if (
+        filters.issue_number !== undefined &&
+        payment.issue_number !== filters.issue_number
+      ) {
+        return false
+      }
+      if (filters.status && payment.status !== filters.status) {
+        return false
+      }
+      return true
+    })
+  },
+  getPayment: (paymentId: string) => {
+    return get().payments.find((payment) => payment.payment_id === paymentId)
+  },
+  setPaymentStatus: (
+    paymentId: string,
+    status: Extract<PaymentStatus, "completed" | "canceled">,
+  ): { payment: Payment; changed: boolean } | undefined => {
+    const existingPayment = get().payments.find(
+      (payment) => payment.payment_id === paymentId,
+    )
+    if (!existingPayment) {
+      return undefined
+    }
+
+    if (existingPayment.status !== "pending") {
+      return { payment: existingPayment, changed: false }
+    }
+
+    const timestamp = now()
+    const updatedPayment: Payment = {
+      ...existingPayment,
+      status,
+      updated_at: timestamp,
+      completed_at: status === "completed" ? timestamp : undefined,
+      canceled_at: status === "canceled" ? timestamp : undefined,
+    }
+
+    set((state) => ({
+      payments: state.payments.map((payment) =>
+        payment.payment_id === paymentId ? updatedPayment : payment,
+      ),
+    }))
+
+    return { payment: updatedPayment, changed: true }
   },
 }))

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -9,8 +9,29 @@ export const thingSchema = z.object({
 })
 export type Thing = z.infer<typeof thingSchema>
 
+export const paymentStatusSchema = z.enum(["pending", "completed", "canceled"])
+export type PaymentStatus = z.infer<typeof paymentStatusSchema>
+
+export const paymentSchema = z.object({
+  payment_id: z.string(),
+  recipient: z.string(),
+  amount: z.number(),
+  currency: z.string(),
+  status: paymentStatusSchema,
+  repository: z.string().optional(),
+  issue_number: z.number().int().positive().optional(),
+  bounty_id: z.string().optional(),
+  idempotency_key: z.string().optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+  completed_at: z.string().optional(),
+  canceled_at: z.string().optional(),
+})
+export type Payment = z.infer<typeof paymentSchema>
+
 export const databaseSchema = z.object({
   idCounter: z.number().default(0),
   things: z.array(thingSchema).default([]),
+  payments: z.array(paymentSchema).default([]),
 })
 export type DatabaseSchema = z.infer<typeof databaseSchema>

--- a/routes/payments/cancel.ts
+++ b/routes/payments/cancel.ts
@@ -1,0 +1,28 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const paymentStatusBodySchema = z.object({
+  payment_id: z.string().min(1),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: paymentStatusBodySchema,
+  jsonResponse: z.object({
+    payment: paymentSchema,
+  }),
+})((req, ctx) => {
+  const result = ctx.db.setPaymentStatus(req.jsonBody.payment_id, "canceled")
+  if (!result) {
+    return Response.json({ error: "Payment not found" }, { status: 404 })
+  }
+  if (!result.changed) {
+    return Response.json(
+      { error: `Payment is already ${result.payment.status}` },
+      { status: 409 },
+    )
+  }
+
+  return ctx.json({ payment: result.payment })
+})

--- a/routes/payments/complete.ts
+++ b/routes/payments/complete.ts
@@ -1,0 +1,28 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const paymentStatusBodySchema = z.object({
+  payment_id: z.string().min(1),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: paymentStatusBodySchema,
+  jsonResponse: z.object({
+    payment: paymentSchema,
+  }),
+})((req, ctx) => {
+  const result = ctx.db.setPaymentStatus(req.jsonBody.payment_id, "completed")
+  if (!result) {
+    return Response.json({ error: "Payment not found" }, { status: 404 })
+  }
+  if (!result.changed) {
+    return Response.json(
+      { error: `Payment is already ${result.payment.status}` },
+      { status: 409 },
+    )
+  }
+
+  return ctx.json({ payment: result.payment })
+})

--- a/routes/payments/get.ts
+++ b/routes/payments/get.ts
@@ -1,0 +1,22 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const getPaymentQuerySchema = z.object({
+  payment_id: z.string().min(1),
+})
+
+export default withRouteSpec({
+  methods: ["GET"],
+  queryParams: getPaymentQuerySchema,
+  jsonResponse: z.object({
+    payment: paymentSchema,
+  }),
+})((req, ctx) => {
+  const payment = ctx.db.getPayment(req.query.payment_id)
+  if (!payment) {
+    return Response.json({ error: "Payment not found" }, { status: 404 })
+  }
+
+  return ctx.json({ payment })
+})

--- a/routes/payments/list.ts
+++ b/routes/payments/list.ts
@@ -1,0 +1,20 @@
+import { paymentSchema, paymentStatusSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const listPaymentsQuerySchema = z.object({
+  recipient: z.string().optional(),
+  repository: z.string().optional(),
+  issue_number: z.coerce.number().int().positive().optional(),
+  status: paymentStatusSchema.optional(),
+})
+
+export default withRouteSpec({
+  methods: ["GET"],
+  queryParams: listPaymentsQuerySchema,
+  jsonResponse: z.object({
+    payments: z.array(paymentSchema),
+  }),
+})((req, ctx) => {
+  return ctx.json({ payments: ctx.db.listPayments(req.query) })
+})

--- a/routes/payments/send.ts
+++ b/routes/payments/send.ts
@@ -1,0 +1,29 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const sendPaymentBodySchema = z.object({
+  recipient: z.string().min(1),
+  amount: z.number().positive(),
+  currency: z.string().min(3).default("USD"),
+  repository: z.string().min(1).optional(),
+  issue_number: z.number().int().positive().optional(),
+  bounty_id: z.string().min(1).optional(),
+  idempotency_key: z.string().min(1).optional(),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: sendPaymentBodySchema,
+  jsonResponse: z.object({
+    payment: paymentSchema,
+    replayed: z.boolean(),
+  }),
+})(async (req, ctx) => {
+  const result = ctx.db.sendPayment({
+    ...req.jsonBody,
+    currency: req.jsonBody.currency.toUpperCase(),
+  })
+
+  return ctx.json(result)
+})

--- a/tests/routes/payments.test.ts
+++ b/tests/routes/payments.test.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+const paymentRequest = {
+  recipient: "octocat",
+  amount: 10,
+  repository: "tscircuit/fake-algora",
+  issue_number: 1,
+  bounty_id: "fake-algora-1",
+}
+
+test("send and list fake payments", async () => {
+  const { axios } = await getTestServer()
+
+  const { data: sendData } = await axios.post("/payments/send", paymentRequest)
+
+  expect(sendData.replayed).toBe(false)
+  expect(sendData.payment).toMatchObject({
+    recipient: "octocat",
+    amount: 10,
+    currency: "USD",
+    repository: "tscircuit/fake-algora",
+    issue_number: 1,
+    bounty_id: "fake-algora-1",
+    status: "pending",
+  })
+  expect(typeof sendData.payment.payment_id).toBe("string")
+  expect(typeof sendData.payment.created_at).toBe("string")
+
+  const { data: listData } = await axios.get("/payments/list")
+
+  expect(listData.payments).toHaveLength(1)
+  expect(listData.payments[0].payment_id).toBe(sendData.payment.payment_id)
+})
+
+test("idempotency key replays the original fake payment", async () => {
+  const { axios } = await getTestServer()
+
+  const { data: firstSend } = await axios.post("/payments/send", {
+    ...paymentRequest,
+    idempotency_key: "send-once",
+  })
+  const { data: replayedSend } = await axios.post("/payments/send", {
+    ...paymentRequest,
+    amount: 25,
+    idempotency_key: "send-once",
+  })
+
+  expect(firstSend.replayed).toBe(false)
+  expect(replayedSend.replayed).toBe(true)
+  expect(replayedSend.payment.payment_id).toBe(firstSend.payment.payment_id)
+  expect(replayedSend.payment.amount).toBe(10)
+
+  const { data: listData } = await axios.get("/payments/list")
+  expect(listData.payments).toHaveLength(1)
+})
+
+test("get and complete a fake payment", async () => {
+  const { axios } = await getTestServer()
+
+  const { data: sendData } = await axios.post("/payments/send", paymentRequest)
+  const paymentId = sendData.payment.payment_id
+
+  const { data: getData } = await axios.get(
+    `/payments/get?payment_id=${paymentId}`,
+  )
+  expect(getData.payment.payment_id).toBe(paymentId)
+
+  const { data: completeData } = await axios.post("/payments/complete", {
+    payment_id: paymentId,
+  })
+
+  expect(completeData.payment).toMatchObject({
+    payment_id: paymentId,
+    status: "completed",
+  })
+  expect(typeof completeData.payment.completed_at).toBe("string")
+})
+
+test("list filters payments and prevents changing terminal payments", async () => {
+  const { axios, url } = await getTestServer()
+
+  const { data: firstSend } = await axios.post("/payments/send", paymentRequest)
+  await axios.post("/payments/send", {
+    recipient: "maintainer",
+    amount: 5,
+    currency: "eur",
+    repository: "tscircuit/other",
+    issue_number: 2,
+  })
+  await axios.post("/payments/complete", {
+    payment_id: firstSend.payment.payment_id,
+  })
+
+  const { data: completedPayments } = await axios.get(
+    "/payments/list?status=completed&repository=tscircuit/fake-algora",
+  )
+  expect(completedPayments.payments).toHaveLength(1)
+  expect(completedPayments.payments[0].payment_id).toBe(
+    firstSend.payment.payment_id,
+  )
+
+  const cancelResponse = await fetch(`${url}/payments/cancel`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ payment_id: firstSend.payment.payment_id }),
+  })
+  expect(cancelResponse.status).toBe(409)
+  expect(await cancelResponse.json()).toEqual({
+    error: "Payment is already completed",
+  })
+})

--- a/tests/routes/payments.test.ts
+++ b/tests/routes/payments.test.ts
@@ -42,6 +42,10 @@ test("idempotency key replays the original fake payment", async () => {
   })
   const { data: replayedSend } = await axios.post("/payments/send", {
     ...paymentRequest,
+    idempotency_key: "send-once",
+  })
+  const { data: distinctSend } = await axios.post("/payments/send", {
+    ...paymentRequest,
     amount: 25,
     idempotency_key: "send-once",
   })
@@ -50,9 +54,12 @@ test("idempotency key replays the original fake payment", async () => {
   expect(replayedSend.replayed).toBe(true)
   expect(replayedSend.payment.payment_id).toBe(firstSend.payment.payment_id)
   expect(replayedSend.payment.amount).toBe(10)
+  expect(distinctSend.replayed).toBe(false)
+  expect(distinctSend.payment.payment_id).not.toBe(firstSend.payment.payment_id)
+  expect(distinctSend.payment.amount).toBe(25)
 
   const { data: listData } = await axios.get("/payments/list")
-  expect(listData.payments).toHaveLength(1)
+  expect(listData.payments).toHaveLength(2)
 })
 
 test("get and complete a fake payment", async () => {
@@ -99,6 +106,11 @@ test("list filters payments and prevents changing terminal payments", async () =
   expect(completedPayments.payments[0].payment_id).toBe(
     firstSend.payment.payment_id,
   )
+
+  const { data: emptyRecipientPayments } = await axios.get(
+    "/payments/list?recipient=",
+  )
+  expect(emptyRecipientPayments.payments).toHaveLength(0)
 
   const cancelResponse = await fetch(`${url}/payments/cancel`, {
     method: "POST",


### PR DESCRIPTION
## Summary
- Add an in-memory fake payment model with pending/completed/canceled lifecycle state
- Add `send`, `list`, `get`, `complete`, and `cancel` payment routes
- Make `/payments/send` retry-safe through optional `idempotency_key` replay
- Document the fake payments API and add route coverage for lifecycle, filtering, and terminal-status guards

/claim #1

## Validation
- `npx --yes bun test tests/routes/payments.test.ts`
- `npx --yes bun test`
- `npx --yes biome check README.md lib/db/db-client.ts lib/db/schema.ts routes/payments/send.ts routes/payments/list.ts routes/payments/get.ts routes/payments/complete.ts routes/payments/cancel.ts tests/routes/payments.test.ts`
- `npx --yes bun run build`
- `npx tsc --noEmit`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and kept the patch scoped.