### PR TITLE
feat: bootstrap payment API with bounties and payments endpoints

### DIFF
--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,16 +1,37 @@
 import { z } from "zod"
 
-// When defining your database schema, try to use snake case for column names.
+  // When defining your database schema, try to use snake case for column names.
 
-export const thingSchema = z.object({
-  thing_id: z.string(),
-  name: z.string(),
-  description: z.string(),
-})
-export type Thing = z.infer<typeof thingSchema>
+  export const thingSchema = z.object({
+    thing_id: z.string(),
+    name: z.string(),
+    description: z.string(),
+  })
+  export type Thing = z.infer<typeof thingSchema>
 
-export const databaseSchema = z.object({
-  idCounter: z.number().default(0),
-  things: z.array(thingSchema).default([]),
-})
-export type DatabaseSchema = z.infer<typeof databaseSchema>
+  export const bountySchema = z.object({
+    bounty_id: z.string(),
+    issue_url: z.string(),
+    amount_usd: z.number(),
+    status: z.enum(["open", "in_progress", "paid"]).default("open"),
+    created_at: z.string(),
+  })
+  export type Bounty = z.infer<typeof bountySchema>
+
+  export const paymentSchema = z.object({
+    payment_id: z.string(),
+    bounty_id: z.string(),
+    recipient_username: z.string(),
+    amount_usd: z.number(),
+    paid_at: z.string(),
+  })
+  export type Payment = z.infer<typeof paymentSchema>
+
+  export const databaseSchema = z.object({
+    idCounter: z.number().default(0),
+    things: z.array(thingSchema).default([]),
+    bounties: z.array(bountySchema).default([]),
+    payments: z.array(paymentSchema).default([]),
+  })
+  export type DatabaseSchema = z.infer<typeof databaseSchema>
+  

--- a/routes/bounties/create.ts
+++ b/routes/bounties/create.ts
@@ -1,0 +1,32 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+  import { z } from "zod"
+  import { randomUUID } from "crypto"
+
+  export default withRouteSpec({
+    methods: ["POST"],
+    jsonBody: z.object({
+      issue_url: z.string().url(),
+      amount_usd: z.number().positive(),
+    }),
+    jsonResponse: z.object({
+      bounty: z.object({
+        bounty_id: z.string(),
+        issue_url: z.string(),
+        amount_usd: z.number(),
+        status: z.string(),
+        created_at: z.string(),
+      }),
+    }),
+  })(async (req, ctx) => {
+    const { issue_url, amount_usd } = await req.json()
+    const bounty = {
+      bounty_id: randomUUID(),
+      issue_url,
+      amount_usd,
+      status: "open" as const,
+      created_at: new Date().toISOString(),
+    }
+    ctx.db.addBounty(bounty)
+    return ctx.json({ bounty })
+  })
+  

--- a/routes/bounties/list.ts
+++ b/routes/bounties/list.ts
@@ -1,0 +1,18 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+  import { z } from "zod"
+
+  export default withRouteSpec({
+    methods: ["GET"],
+    jsonResponse: z.object({
+      bounties: z.array(z.object({
+        bounty_id: z.string(),
+        issue_url: z.string(),
+        amount_usd: z.number(),
+        status: z.string(),
+        created_at: z.string(),
+      })),
+    }),
+  })(async (req, ctx) => {
+    return ctx.json({ bounties: ctx.db.getBounties() })
+  })
+  

--- a/routes/payments/create.ts
+++ b/routes/payments/create.ts
@@ -1,0 +1,33 @@
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+  import { z } from "zod"
+  import { randomUUID } from "crypto"
+
+  export default withRouteSpec({
+    methods: ["POST"],
+    jsonBody: z.object({
+      bounty_id: z.string(),
+      recipient_username: z.string(),
+      amount_usd: z.number().positive(),
+    }),
+    jsonResponse: z.object({
+      payment: z.object({
+        payment_id: z.string(),
+        bounty_id: z.string(),
+        recipient_username: z.string(),
+        amount_usd: z.number(),
+        paid_at: z.string(),
+      }),
+    }),
+  })(async (req, ctx) => {
+    const { bounty_id, recipient_username, amount_usd } = await req.json()
+    const payment = {
+      payment_id: randomUUID(),
+      bounty_id,
+      recipient_username,
+      amount_usd,
+      paid_at: new Date().toISOString(),
+    }
+    ctx.db.addPayment(payment)
+    return ctx.json({ payment })
+  })
+  


### PR DESCRIPTION
Closes #1

  ## What this adds

  ### Schema
  - `bountySchema` — tracks a bounty linked to a GitHub issue URL with a USD amount and status (`open` | `in_progress` | `paid`)
  - `paymentSchema` — records a payment sent to a recipient for completing a bounty

  ### Routes
  - `POST /bounties/create` — create a new bounty with `issue_url` and `amount_usd`
  - `GET /bounties/list` — list all bounties
  - `POST /payments/create` — send a payment (`bounty_id`, `recipient_username`, `amount_usd`)

  All routes follow the existing winterspec + zod pattern used in the project.