### PR TITLE
Add fake payment API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,14 @@ This is a template project with best-practice modules:
 - Winterspec for defining the API
 - bun testing
 - Zustand store with zod definition for database state
+
+## Payment API
+
+The fake payment flow supports creating and tracking bounty payouts:
+
+- `POST /payments/send` creates a pending payment. Send `recipient`, `amount`, optional `currency`, `idempotency_key`, `bounty_issue`, and `memo`.
+- `GET /payments/list` returns payments and supports `recipient`, `status`, and `bounty_issue` filters.
+- `GET /payments/get?payment_id=...` returns one payment or `null`.
+- `POST /payments/update-status` updates a payment to `pending`, `completed`, `canceled`, or `failed`.
+
+Repeated `/payments/send` requests with the same `idempotency_key` return the existing payment with `replayed: true`.

--- a/lib/db/db-client.ts
+++ b/lib/db/db-client.ts
@@ -1,9 +1,15 @@
-import { createStore, type StoreApi } from "zustand/vanilla"
+import { type HoistedStoreApi, hoist } from "zustand-hoist"
 import { immer } from "zustand/middleware/immer"
-import { hoist, type HoistedStoreApi } from "zustand-hoist"
+import { type StoreApi, createStore } from "zustand/vanilla"
 
-import { databaseSchema, type DatabaseSchema, type Thing } from "./schema.ts"
 import { combine } from "zustand/middleware"
+import {
+  type DatabaseSchema,
+  type Payment,
+  type PaymentStatus,
+  type Thing,
+  databaseSchema,
+} from "./schema.ts"
 
 export const createDatabase = () => {
   return hoist(createStore(initializer))
@@ -11,7 +17,12 @@ export const createDatabase = () => {
 
 export type DbClient = ReturnType<typeof createDatabase>
 
-const initializer = combine(databaseSchema.parse({}), (set) => ({
+type CreatePaymentInput = Omit<
+  Payment,
+  "payment_id" | "status" | "created_at" | "updated_at"
+>
+
+const initializer = combine(databaseSchema.parse({}), (set, get) => ({
   addThing: (thing: Omit<Thing, "thing_id">) => {
     set((state) => ({
       things: [
@@ -20,5 +31,57 @@ const initializer = combine(databaseSchema.parse({}), (set) => ({
       ],
       idCounter: state.idCounter + 1,
     }))
+  },
+  createPayment: (paymentInput: CreatePaymentInput) => {
+    const existingPayment = paymentInput.idempotency_key
+      ? get().payments.find(
+          (payment) => payment.idempotency_key === paymentInput.idempotency_key,
+        )
+      : undefined
+
+    if (existingPayment) {
+      return { payment: existingPayment, replayed: true }
+    }
+
+    const now = new Date().toISOString()
+    const payment: Payment = {
+      ...paymentInput,
+      payment_id: get().idCounter.toString(),
+      status: "pending",
+      created_at: now,
+      updated_at: now,
+    }
+
+    set((state) => ({
+      payments: [...state.payments, payment],
+      idCounter: state.idCounter + 1,
+    }))
+
+    return { payment, replayed: false }
+  },
+  updatePaymentStatus: (
+    paymentId: string,
+    status: PaymentStatus,
+  ): Payment | undefined => {
+    let updatedPayment: Payment | undefined
+    const now = new Date().toISOString()
+
+    set((state) => ({
+      payments: state.payments.map((payment) => {
+        if (payment.payment_id !== paymentId) {
+          return payment
+        }
+
+        updatedPayment = {
+          ...payment,
+          status,
+          updated_at: now,
+        }
+
+        return updatedPayment
+      }),
+    }))
+
+    return updatedPayment
   },
 }))

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -9,8 +9,31 @@ export const thingSchema = z.object({
 })
 export type Thing = z.infer<typeof thingSchema>
 
+export const paymentStatusSchema = z.enum([
+  "pending",
+  "completed",
+  "canceled",
+  "failed",
+])
+export type PaymentStatus = z.infer<typeof paymentStatusSchema>
+
+export const paymentSchema = z.object({
+  payment_id: z.string(),
+  recipient: z.string(),
+  amount: z.number(),
+  currency: z.string(),
+  status: paymentStatusSchema,
+  idempotency_key: z.string().optional(),
+  bounty_issue: z.string().optional(),
+  memo: z.string().optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+})
+export type Payment = z.infer<typeof paymentSchema>
+
 export const databaseSchema = z.object({
   idCounter: z.number().default(0),
   things: z.array(thingSchema).default([]),
+  payments: z.array(paymentSchema).default([]),
 })
 export type DatabaseSchema = z.infer<typeof databaseSchema>

--- a/routes/payments/get.ts
+++ b/routes/payments/get.ts
@@ -1,0 +1,17 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  jsonResponse: z.object({
+    payment: paymentSchema.nullable(),
+  }),
+})((req, ctx) => {
+  const url = new URL(req.url)
+  const paymentId = url.searchParams.get("payment_id")
+  const payment =
+    ctx.db.payments.find((record) => record.payment_id === paymentId) ?? null
+
+  return ctx.json({ payment })
+})

--- a/routes/payments/list.ts
+++ b/routes/payments/list.ts
@@ -1,0 +1,35 @@
+import { paymentSchema, paymentStatusSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+export default withRouteSpec({
+  methods: ["GET"],
+  jsonResponse: z.object({
+    payments: z.array(paymentSchema),
+  }),
+})((req, ctx) => {
+  const url = new URL(req.url)
+  const recipient = url.searchParams.get("recipient")
+  const bountyIssue = url.searchParams.get("bounty_issue")
+  const status = paymentStatusSchema
+    .optional()
+    .safeParse(url.searchParams.get("status") ?? undefined)
+
+  const payments = ctx.db.payments.filter((payment) => {
+    if (recipient && payment.recipient !== recipient) {
+      return false
+    }
+
+    if (bountyIssue && payment.bounty_issue !== bountyIssue) {
+      return false
+    }
+
+    if (status.success && status.data && payment.status !== status.data) {
+      return false
+    }
+
+    return true
+  })
+
+  return ctx.json({ payments })
+})

--- a/routes/payments/send.ts
+++ b/routes/payments/send.ts
@@ -1,0 +1,26 @@
+import { paymentSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const paymentRequestSchema = z.object({
+  recipient: z.string().min(1),
+  amount: z.number().positive(),
+  currency: z.string().min(1).default("USD"),
+  idempotency_key: z.string().min(1).optional(),
+  bounty_issue: z.string().min(1).optional(),
+  memo: z.string().min(1).optional(),
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: paymentRequestSchema,
+  jsonResponse: z.object({
+    payment: paymentSchema,
+    replayed: z.boolean(),
+  }),
+})(async (req, ctx) => {
+  const paymentInput = paymentRequestSchema.parse(await req.json())
+  const { payment, replayed } = ctx.db.createPayment(paymentInput)
+
+  return ctx.json({ payment, replayed })
+})

--- a/routes/payments/update-status.ts
+++ b/routes/payments/update-status.ts
@@ -1,0 +1,24 @@
+import { paymentSchema, paymentStatusSchema } from "lib/db/schema"
+import { withRouteSpec } from "lib/middleware/with-winter-spec"
+import { z } from "zod"
+
+const updateStatusRequestSchema = z.object({
+  payment_id: z.string().min(1),
+  status: paymentStatusSchema,
+})
+
+export default withRouteSpec({
+  methods: ["POST"],
+  jsonBody: updateStatusRequestSchema,
+  jsonResponse: z.object({
+    ok: z.boolean(),
+    payment: paymentSchema.nullable(),
+  }),
+})(async (req, ctx) => {
+  const { payment_id, status } = updateStatusRequestSchema.parse(
+    await req.json(),
+  )
+  const payment = ctx.db.updatePaymentStatus(payment_id, status) ?? null
+
+  return ctx.json({ ok: Boolean(payment), payment })
+})

--- a/tests/routes/payments.test.ts
+++ b/tests/routes/payments.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "bun:test"
+import { getTestServer } from "tests/fixtures/get-test-server"
+
+test("send a payment and replay idempotent requests", async () => {
+  const { axios } = await getTestServer()
+
+  const requestBody = {
+    recipient: "alice@example.com",
+    amount: 10,
+    currency: "USD",
+    idempotency_key: "bounty-1-payment",
+    bounty_issue: "https://github.com/tscircuit/fake-algora/issues/1",
+    memo: "Bounty payment",
+  }
+
+  const firstResponse = await axios.post("/payments/send", requestBody)
+  const replayResponse = await axios.post("/payments/send", requestBody)
+
+  expect(firstResponse.data.replayed).toBe(false)
+  expect(replayResponse.data.replayed).toBe(true)
+  expect(replayResponse.data.payment.payment_id).toBe(
+    firstResponse.data.payment.payment_id,
+  )
+
+  const listResponse = await axios.get("/payments/list")
+  expect(listResponse.data.payments).toHaveLength(1)
+})
+
+test("list, get, and update payment status", async () => {
+  const { axios } = await getTestServer()
+
+  const sendResponse = await axios.post("/payments/send", {
+    recipient: "bob@example.com",
+    amount: 25,
+    currency: "USD",
+  })
+  const paymentId = sendResponse.data.payment.payment_id
+
+  const filteredResponse = await axios.get(
+    "/payments/list?recipient=bob@example.com&status=pending",
+  )
+  expect(filteredResponse.data.payments).toHaveLength(1)
+
+  const getResponse = await axios.get(`/payments/get?payment_id=${paymentId}`)
+  expect(getResponse.data.payment.recipient).toBe("bob@example.com")
+
+  const updateResponse = await axios.post("/payments/update-status", {
+    payment_id: paymentId,
+    status: "completed",
+  })
+  expect(updateResponse.data.ok).toBe(true)
+  expect(updateResponse.data.payment.status).toBe("completed")
+
+  const completedResponse = await axios.get("/payments/list?status=completed")
+  expect(completedResponse.data.payments).toHaveLength(1)
+})


### PR DESCRIPTION
/claim #1

## Summary
- add fake payment records to the shared zod/zustand database schema
- add Winterspec routes to send, list, get, and update fake payment status
- support idempotency-key replay so retrying a send returns the original payment instead of creating duplicates
- document the payment endpoints and cover the flow with Bun route tests

## Verification
- `bun test` -> 4 pass, 0 fail
- `bunx biome check lib/db/schema.ts lib/db/db-client.ts routes/payments tests/routes/payments.test.ts README.md` -> clean
- `bun run build` -> bundled successfully
- `bunx tsc --noEmit` -> clean after build generated `dist/bundle`
- `git diff --check` -> clean

AI-assisted with OpenAI Codex; I reviewed the diff and kept the implementation scoped. No private payout details are included here.